### PR TITLE
Show all clients on the clients page instead of using pagination.

### DIFF
--- a/ci/templates/ci/clients.html
+++ b/ci/templates/ci/clients.html
@@ -30,7 +30,6 @@ You are not allowed to view the job clients.
     {% endfor %}
     </tbody>
   </table>
-  {% include "ci/page_handler.html" with objs=clients %}
 {% else %}
 No Clients
 {% endif %}

--- a/ci/views.py
+++ b/ci/views.py
@@ -374,8 +374,7 @@ def client_list(request):
     return render(request, 'ci/clients.html', {'clients': None, 'allowed': False})
 
   client_list = models.Client.objects.order_by('name').all()
-  clients = get_paginated(request, client_list)
-  return render(request, 'ci/clients.html', {'clients': clients, 'allowed': True})
+  return render(request, 'ci/clients.html', {'clients': client_list, 'allowed': True})
 
 def event_list(request):
   event_list = get_default_events_query()


### PR DESCRIPTION
Now that we have all the new build boxes up, it is nice to have all the clients on the same page.
