### PR TITLE
Post comment to GitLab on source error

### DIFF
--- a/ci/tests/test_html_validate.py
+++ b/ci/tests/test_html_validate.py
@@ -46,7 +46,8 @@ class Tests(TestCase):
     response = self.client.get(url)
     vld = HTMLValidator()
     vld.validate_fragment(response.content)
-    print(response.content)
+    if vld.errors or vld.warnings:
+      print(response.content)
     if vld.errors:
       print("ERRORS: %s" % json.dumps(vld.errors, indent=4))
     if vld.warnings:


### PR DESCRIPTION
When we can't get the source branch it usually means access hasn't been given to moosetest.
Add a comment to the merge request to explain.

closes #92
