### PR TITLE
Fix push event query

### DIFF
--- a/ci/PushEvent.py
+++ b/ci/PushEvent.py
@@ -51,7 +51,6 @@ class PushEvent(object):
         build_user=self.build_user,
         head=head,
         base=base,
-        complete=False,
         cause=models.Event.PUSH,
         )
     if not created:
@@ -82,5 +81,3 @@ class PushEvent(object):
           job.save()
           logger.info('Created job {}: {}: on {}'.format(job.pk, job, r.repository))
     event.make_jobs_ready(ev)
-
-


### PR DESCRIPTION
If the same push event is sent twice, the second one after the first one is complete, the second Push event would fail.
This doesn't usually happen but I have seen it with GitLab.
It doesn't actually affect anything but it removes the error from the logs.
