### PR TITLE
Cancel bad job instead of invalidate

### DIFF
--- a/ci/client/tests/test_views.py
+++ b/ci/client/tests/test_views.py
@@ -44,10 +44,10 @@ class Tests(ClientTester.ClientTester):
     # associated with that client. That must mean
     # that the client previously stopped without letting the
     # server know, so the previous job should get
-    # invalidated
+    # canceled
     self.set_counts()
     response = self.client.get(url)
-    self.compare_counts(invalidated=1, num_changelog=1)
+    self.compare_counts(canceled=1, events_canceled=1, num_jobs_completed=1, num_changelog=1)
     self.assertEqual(response.status_code, 200)
 
     # Try again, nothing should change

--- a/ci/client/views.py
+++ b/ci/client/views.py
@@ -61,11 +61,11 @@ def ready_jobs(request, build_key, client_name):
     logger.debug('New client %s : %s seen' % (client_name, get_client_ip(request)))
   else:
     # if a client is talking to us here then if they have any running jobs assigned to them they need
-    # to be invalidated
+    # to be canceled
     past_running_jobs = models.Job.objects.filter(client=client, complete=False, status=models.JobStatus.RUNNING)
-    msg = "Invalidated due to client %s not finishing job" % client.name
+    msg = "Canceled due to client %s not finishing job" % client.name
     for j in past_running_jobs.all():
-      views.set_job_invalidated(j, msg)
+      views.set_job_canceled(j, msg)
 
   client.status_message = 'Looking for work'
   client.status = models.Client.IDLE


### PR DESCRIPTION
If a client dies while running a job, mark it as canceled instead of invalidated on the idea that there is probably something
wrong with the client.
