### PR TITLE
Post github comments on certain job steps

### DIFF
--- a/ci/PullRequestEvent.py
+++ b/ci/PullRequestEvent.py
@@ -18,6 +18,7 @@ class PullRequestEvent(object):
     base_commit : GitCommitData of the base sha
     head_commit : GitCommitData of the head sha
     comments_url : Url to the comments
+    review_comments_url : Url to the review comments
     html_url : Http URL to the repo
     full_text : All the payload data
     build_user : GitUser corresponding to the build user
@@ -39,6 +40,7 @@ class PullRequestEvent(object):
     self.html_url = None
     self.full_text = None
     self.comments_url = None
+    self.review_comments_url = None
     self.description = ''
     self.trigger_user = ''
 
@@ -82,6 +84,7 @@ class PullRequestEvent(object):
     pr.closed = False
     pr.url = self.html_url
     pr.username = self.trigger_user
+    pr.review_comments_url = self.review_comments_url
     pr.save()
     pr.repository.active = True
     pr.repository.save()
@@ -89,7 +92,6 @@ class PullRequestEvent(object):
       logger.info('Pull request {}: {} already exists'.format(pr.pk, pr))
     else:
       logger.info('Pull request created {}: {}'.format(pr.pk, pr))
-
 
     ev, ev_created = models.Event.objects.get_or_create(
         build_user=self.build_user,
@@ -195,7 +197,7 @@ class PullRequestEvent(object):
           msg = 'Developer needed to activate'
           git_status = server.api().SUCCESS
           comment = 'A build job for {} from recipe {} is waiting for a developer to activate it here: {}'.format(ev.head.sha, recipe.name, abs_job_url)
-          server.api().pr_comment(oauth_session, ev.comments_url, comment)
+          server.api().pr_job_status_comment(oauth_session, ev.comments_url, comment)
 
         server.api().update_pr_status(
                 oauth_session,

--- a/ci/bitbucket/api.py
+++ b/ci/bitbucket/api.py
@@ -128,6 +128,17 @@ class BitBucketAPI(GitAPI):
     logger.debug('User %s is not a collaborator on %s' % (user, repo))
     return False
 
+  def pr_review_comment(self, oauth_session, url, msg):
+    """
+    FIXME: Need to implement
+    """
+
+  def pr_job_status_comment(self, oauth_session, url, msg):
+    """
+    Nothing special, just do a regular PR comment
+    """
+    self.pr_comment(oauth_session, url, msg)
+
   def pr_comment(self, oauth_session, url, msg):
     """
     Add a comment on a PR

--- a/ci/bitbucket/tests/test_api.py
+++ b/ci/bitbucket/tests/test_api.py
@@ -268,6 +268,7 @@ class Tests(TestCase):
     auth = user.server.auth().start_session_for_user(user)
     # valid post
     bapi.pr_comment(auth, 'url', 'message')
+    bapi.pr_job_status_comment(auth, 'url', 'message')
 
     # bad post
     mock_post.return_value = utils.Response(status_code=400, json_data={'message': 'bad post'})

--- a/ci/client/ProcessCommands.py
+++ b/ci/client/ProcessCommands.py
@@ -1,0 +1,66 @@
+from ci import models
+import re
+
+def find_in_output(output, key):
+  """
+  Find a key in the output and return its value.
+  """
+  matches = re.search("^%s=(.*)" % key, output)
+  if matches:
+    return matches.groups()[0]
+  return None
+
+def get_output_by_position(job, position):
+  """
+  Utility function to get the output of a job step result by position
+  """
+  return job.step_results.get(position=position).output
+
+def check_submodule_update(job, position):
+  """
+  Checks to see if certain submodules have been updated and post a comment to the PR if so.
+  """
+  output = get_output_by_position(job, position)
+  modules = find_in_output(output, "CIVET_CLIENT_SUBMODULE_UPDATES")
+  if not modules:
+    return
+  if not job.event.pull_request or not job.event.pull_request.review_comments_url:
+    return
+  for mod in modules.split():
+    oauth_session = job.event.build_user.start_session()
+    api = job.event.pull_request.repository.server().api()
+    url = job.event.pull_request.review_comments_url
+    sha = job.event.head.sha
+    msg = "**Caution!** This contains a submodule update"
+    # The 2 position will leave the message on the new submodule hash
+    api.pr_review_comment(oauth_session, url, sha, mod, 2, msg)
+
+def check_post_comment(job, position):
+  """
+  Checks to see if we should post a message to the PR.
+  """
+  output = get_output_by_position(job, position)
+  message = find_in_output(output, "CIVET_CLIENT_POST_MESSAGE")
+  if message and job.event.comments_url:
+    oauth_session = job.event.build_user.start_session()
+    msg = "Job %s on %s wanted to post the following:\n\n%s" % (job, job.event.head.sha[:7], message)
+    api = job.event.pull_request.repository.server().api()
+    url = job.event.comments_url
+    api.pr_comment(oauth_session, url, msg)
+
+def process_commands(job):
+  """
+  See if we need to check for any commands on this job.
+  Commands take the form of an environment variable set on the recipe to
+  indicate that we need to check the output for certain key value pairs.
+  """
+  if job.event.cause != models.Event.PULL_REQUEST:
+    return
+  for step in job.recipe.steps.prefetch_related("step_environment").all():
+    for step_env in step.step_environment.all():
+      if step_env.name == "CIVET_SERVER_POST_ON_SUBMODULE_UPDATE" and step_env.value == "1":
+        check_submodule_update(job, step.position)
+        break
+      elif step_env.name == "CIVET_SERVER_POST_COMMENT" and step_env.value == "1":
+        check_post_comment(job, step.position)
+        break

--- a/ci/client/tests/test_ProcessCommands.py
+++ b/ci/client/tests/test_ProcessCommands.py
@@ -1,0 +1,74 @@
+import ClientTester
+from ci.client import ProcessCommands
+from ci.tests import utils
+from ci import models
+
+class Tests(ClientTester.ClientTester):
+  def test_find_in_output(self):
+    s = " Foo=some value"
+    r = ProcessCommands.find_in_output(s, "Foo")
+    self.assertEqual(r, None)
+    s = s.strip()
+    r = ProcessCommands.find_in_output(s, "Foo")
+    s = "Foo = bar"
+    r = ProcessCommands.find_in_output(s, "Foo")
+    self.assertEqual(r, None)
+    s = "Foo="
+    r = ProcessCommands.find_in_output(s, "Foo")
+    self.assertEqual(r, "")
+
+  def create_step_result(self, output):
+    result = utils.create_step_result()
+    result.output = output
+    result.save()
+    ev = result.job.event
+    ev.pull_request = utils.create_pr()
+    ev.pull_request.review_comments_url = "review_comments"
+    ev.pull_request.save()
+    ev.comments_url = "url"
+    ev.save()
+    return result
+
+  def test_check_submodule_update(self):
+    result = self.create_step_result("CIVET_CLIENT_SUBMODULE_UPDATES=1")
+    ProcessCommands.check_submodule_update(result.job, result.position)
+
+  def test_check_post_comment(self):
+    result = self.create_step_result("CIVET_CLIENT_POST_MESSAGE=My message")
+    ProcessCommands.check_post_comment(result.job, result.position)
+
+  def test_process_commands(self):
+    """
+    Hard to test these so just get coverage.
+    """
+    update_key = "CIVET_CLIENT_SUBMODULE_UPDATES"
+    post_key = "CIVET_CLIENT_POST_MESSAGE"
+    result = self.create_step_result("%s=libmesh\n%s=My message" % (update_key, post_key))
+    ev = result.job.event
+    job = result.job
+    ev.cause = models.Event.PUSH
+    ev.save()
+    step = job.recipe.steps.first()
+    ProcessCommands.process_commands(job)
+
+    ev.cause = models.Event.PULL_REQUEST
+    ev.save()
+    ProcessCommands.process_commands(job)
+
+    utils.create_step_environment(name="CIVET_SERVER_POST_ON_SUBMODULE_UPDATE", value="1", step=step)
+    ProcessCommands.process_commands(job)
+    result.output = ""
+    result.save()
+    ProcessCommands.process_commands(job)
+    result.output = "%s=" % update_key
+    result.save()
+    ProcessCommands.process_commands(job)
+    ev.pull_request.review_comments_url = None
+    ev.pull_request.save()
+    result.output = "%s=libmesh" % update_key
+    result.save()
+    ProcessCommands.process_commands(job)
+
+    step.step_environment.all().delete()
+    utils.create_step_environment(name="CIVET_SERVER_POST_COMMENT", value="1", step=step)
+    ProcessCommands.process_commands(job)

--- a/ci/client/views.py
+++ b/ci/client/views.py
@@ -8,7 +8,7 @@ import logging
 from django.conf import settings
 from django.db import transaction
 from datetime import timedelta
-import ParseOutput
+import ParseOutput, ProcessCommands
 import UpdateRemoteStatus
 logger = logging.getLogger('ci')
 
@@ -317,6 +317,7 @@ def job_finished(request, build_key, client_name, job_id):
   UpdateRemoteStatus.job_complete_pr_status(request, job)
 
   ParseOutput.set_job_info(job)
+  ProcessCommands.process_commands(job)
 
   # now check if all configs are finished
   all_complete = True

--- a/ci/git_api.py
+++ b/ci/git_api.py
@@ -103,6 +103,29 @@ class GitAPI(object):
     """
 
   @abc.abstractmethod
+  def pr_job_status_comment(self, oauth_session, url, msg):
+    """
+    Leave a comment on a PR to indicate the status of a job
+    Input:
+      auth_session: requests_oauthlib.OAuth2Session for the user
+      url: str: URL to post the message to
+      msg: str: Comment
+    """
+
+  @abc.abstractmethod
+  def pr_review_comment(self, oauth_session, url, sha, filepath, position, msg):
+    """
+    Leave a review comment on a PR for a specific hash, on a specific position of a file
+    Input:
+      auth_session: requests_oauthlib.OAuth2Session for the user
+      url: str: URL to post the message to
+      sha: str: SHA of the PR branch to attach the message to
+      filepath: str: Filepath of the file to attach the message to
+      position: str: Position in the diff to attach the message to
+      msg: str: Comment
+    """
+
+  @abc.abstractmethod
   def pr_comment(self, oauth_session, url, msg):
     """
     Leave a comment on a PR

--- a/ci/github/views.py
+++ b/ci/github/views.py
@@ -65,6 +65,7 @@ def process_pull_request(user, data):
   pr_event.trigger_user = pr_data['user']['login']
   pr_event.build_user = user
   pr_event.comments_url = pr_data['comments_url']
+  pr_event.review_comments_url = pr_data['review_comments_url']
   pr_event.title = pr_data['title']
 
   for prefix in settings.GITHUB_PR_WIP_PREFIX:

--- a/ci/gitlab/api.py
+++ b/ci/gitlab/api.py
@@ -232,7 +232,37 @@ class GitLabAPI(GitAPI):
 
     return self.is_group_member(oauth_session, token, group_id, user.name)
 
+  def pr_review_comment(self, oauth_session, url, sha, filepath, position, msg):
+    """
+    FIXME: Disabled for now.
+    if not settings.REMOTE_UPDATE:
+      return
+
+    comment = {'note': msg,
+        "sha": sha,
+        "id": ,
+        "path": filepath,
+        "line": position,
+        }
+    try:
+      token = self.get_token(oauth_session)
+      logger.info('POSTing to {}:{}: {}'.format(url, token, comment))
+      response = self.post(url, token, data=comment)
+      logger.info('Response: {}'.format(response.json()))
+    except Exception as e:
+      logger.warning("Failed to leave commit comment.\nComment: %s\nError: %s" %(msg, traceback.format_exc(e)))
+    """
+
+  def pr_job_status_comment(self, oauth_session, url, msg):
+    """
+    Doesn't need to do anything special, just call pr_comment
+    """
+    self.pr_comment(oauth_session, url, msg)
+
   def pr_comment(self, oauth_session, url, msg):
+    """
+    Post a comment to a PR
+    """
     if not settings.REMOTE_UPDATE:
       return
 

--- a/ci/gitlab/tests/test_api.py
+++ b/ci/gitlab/tests/test_api.py
@@ -258,6 +258,7 @@ class Tests(DBTester.DBTester):
     auth = user.server.auth().start_session_for_user(user)
     # valid post
     gapi.pr_comment(auth, 'url', 'message')
+    gapi.pr_job_status_comment(auth, 'url', 'message')
 
     # bad post
     mock_post.side_effect = Exception()

--- a/ci/models.py
+++ b/ci/models.py
@@ -229,6 +229,7 @@ class PullRequest(models.Model):
   closed = models.BooleanField(default=False)
   created = models.DateTimeField(auto_now_add=True)
   status = models.IntegerField(choices=JobStatus.STATUS_CHOICES, default=JobStatus.NOT_STARTED)
+  review_comments_url = models.URLField(null=True, blank=True)
   alternate_recipes = models.ManyToManyField("Recipe", blank=True, related_name="pull_requests")
   last_modified = models.DateTimeField(auto_now=True)
 

--- a/ci/recipe/tests/test_RecipeCreator.py
+++ b/ci/recipe/tests/test_RecipeCreator.py
@@ -21,7 +21,6 @@ class Tests(RecipeTester.RecipeTester):
     self.compare_counts(recipes=6, sha_changed=True, current=6, users=1, repos=1, branches=1, deps=2,
         num_push_recipes=2, num_manual_recipes=1, num_pr_recipes=2, num_pr_alt_recipes=1,
         num_steps=11, num_step_envs=44, num_recipe_envs=11, num_prestep=12)
-    print("--------- Created valid recipes ----------")
 
   def test_no_recipes(self):
     # no recipes, nothing to do


### PR DESCRIPTION
Specify certain steps in a recipe as possibly wanting to post a comment to GitHub.
For such a step, the output will be scanned to determine what to post.
This is primarily intended for two reasons:
1. For submodule updates CIVET will post a review comment on the changed submodule.
2. For MOOSE documentation, the temporary site URL will be posted to the PR.
