### PR TITLE
Add ability to post comment when invalidating or cancelling jobs

### DIFF
--- a/ci/models.py
+++ b/ci/models.py
@@ -682,7 +682,7 @@ class JobChangeLog(models.Model):
   created = models.DateTimeField(auto_now_add=True)
 
   def __unicode__(self):
-    out = "%s %s" % (self.message, TimeUtils.display_time_str(self.created))
+    out = "%s - %s" % (self.message, TimeUtils.display_time_str(self.created))
     return out
 
   class Meta:

--- a/ci/templates/ci/event.html
+++ b/ci/templates/ci/event.html
@@ -44,22 +44,62 @@
 </div>
 {% if allowed_to_cancel and not event.complete %}
   <div class="row">
-    <div class="col-sm-8">
-      <form action={% url "ci:cancel_event" event.pk %} method="post" id="cancel_form">
-        {% csrf_token %}
-        <button type="submit" class="btn btn-warning">Cancel all jobs</button>
-      </form>
+    <div class="col-sm-12">
+      <a class="btn btn-warning" role="button" data-toggle="collapse" href="#cancelForm" aria-expanded="false" aria-controls="cancelForm">
+        Cancel all jobs
+      </a>
+      <div class="collapse" id="cancelForm">
+        <div class="well">
+          <form action={% url "ci:cancel_event" event.pk %} method="post" id="cancelForm">
+            {% csrf_token %}
+            <div class="form-group">
+              <label for="cancelComment">Comment</label>
+              <input class="form-control" id="cancelComment" name="comment">
+            </div>
+            {% if event.pull_request %}
+              <div class="checkbox">
+                <label>
+                  <input name="post_to_pr" type="checkbox">Post comment to PR
+                </label>
+              </div>
+            {% endif %}
+            <button type="submit" class="btn btn-default">Submit</button>
+          </form>
+        </div>
+      </div>
     </div>
   </div>
 {% endif %}
 {% if allowed_to_cancel %}
   <div class="row">
-    <div class="col-sm-8">
-      <form action={% url "ci:invalidate_event" event.pk %} method="post" role="form" id="invalidate_form">
-        {% csrf_token %}
-        <button type="submit" class="btn btn-primary">Invalidate all jobs</button>
-        <label><input type="checkbox" name="same_client"> Run on same clients</label>
-      </form>
+    <div class="col-sm-12">
+      <a class="btn btn-primary" role="button" data-toggle="collapse" href="#invalidateForm" aria-expanded="false" aria-controls="invalidateForm">
+        Invalidate all jobs
+      </a>
+      <div class="collapse" id="invalidateForm">
+        <div class="well">
+          <form action={% url "ci:invalidate_event" event.pk %} method="post" role="form" id="invalidate_form">
+            {% csrf_token %}
+            <div class="form-group">
+              <label for="invalidateComment">Comment</label>
+              <input class="form-control" id="invalidateComment" name="comment">
+            </div>
+            {% if event.pull_request %}
+              <div class="checkbox">
+                <label>
+                  <input name="post_to_pr" type="checkbox">Post comment to PR
+                </label>
+              </div>
+            {% endif %}
+            <div class="checkbox">
+              <label class="form-group">
+                <input type="checkbox" name="same_client"> Run on same clients
+              </label>
+            </div>
+            <button type="submit" class="btn btn-default">Submit</button>
+          </form>
+        </div>
+      </div>
     </div>
   </div>
 {% endif %}

--- a/ci/templates/ci/job.html
+++ b/ci/templates/ci/job.html
@@ -117,35 +117,74 @@
 {% if job.active %}
   {% if can_admin and not job.complete %}
     <div class="row">
-      <div class="col-sm-1">
-        <form id="cancel" action="{% url "ci:cancel_job" job.pk %}" method="post">
-          {% csrf_token %}
-          <button type="submit" class="btn btn-warning" title="This will stop the current job (if running) and allow it to start it again.">Cancel job</button>
-        </form>
+      <div class="col-sm-12">
+        <a class="btn btn-warning" role="button" data-toggle="collapse" href="#cancelForm" aria-expanded="false" aria-controls="cancelForm">
+          Cancel Job
+        </a>
+        <div class="collapse" id="cancelForm">
+          <div class="well">
+            <form id="cancel" action="{% url "ci:cancel_job" job.pk %}" method="post">
+              {% csrf_token %}
+              <div class="form-group">
+                <label for="cancelComment">Comment</label>
+                <input class="form-control" id="cancelComment" name="comment">
+              </div>
+              {% if job.event.pull_request %}
+                <div class="checkbox">
+                  <label>
+                    <input name="post_to_pr" type="checkbox">Post comment to PR
+                  </label>
+                </div>
+              {% endif %}
+              <button type="submit" class="btn btn-default" title="This will cancel the current job and immediately stop it.">Submit</button>
+            </form>
+          </div>
+        </div>
       </div>
     </div>
   {% endif %}
   {% if can_admin %}
     <div class="row">
       <div class="col-sm-12">
-        <form id="invalidate" action="{% url "ci:invalidate" job.pk %}" method="post">
-          {% csrf_token %}
-          <div class="form-group">
-            <button type="submit" class="col-sm-2 btn btn-primary" title="This will stop the current job (if running) and allow it to start it again.">Invalidate job</button>
-            {% if clients %}
-              <div class="col-sm-3">
-                <select class="form-control" id="client_list" name="client_list">
-                  <option value="0">Any client</option>
-                  {% for client in clients %}
-                    <option value="{{ client.pk }}">{{ client.name }}</option>
-                  {% endfor %}
-                </select>
-              {% else %}
-                <label class="col-sm-3"><input type="checkbox" name="same_client"> Run on same client</label>
+        <a class="btn btn-primary" role="button" data-toggle="collapse" href="#invalidateForm" aria-expanded="false" aria-controls="invalidateForm">
+          Invalidate Job
+        </a>
+        <div class="collapse" id="invalidateForm">
+          <div class="well">
+            <form id="invalidate" action="{% url "ci:invalidate" job.pk %}" method="post">
+              {% csrf_token %}
+              <div class="form-group">
+                <label for="invalidateComment">Comment</label>
+                <input class="form-control" id="invalidateComment" name="comment">
+              </div>
+              {% if job.event.pull_request %}
+                <div class="checkbox">
+                  <label>
+                    <input name="post_to_pr" type="checkbox">Post comment to PR
+                  </label>
+                </div>
               {% endif %}
-            </div>
+              {% if clients %}
+                <div class="form-group">
+                  <label for="client_list">Client to run on</label>
+                  <select class="form-control" id="client_list" name="client_list">
+                    <option value="0">Any client</option>
+                    {% for client in clients %}
+                      <option value="{{ client.pk }}">{{ client.name }}</option>
+                    {% endfor %}
+                  </select>
+                </div>
+              {% else %}
+                <div class="checkbox">
+                  <label class="form-group">
+                    <input type="checkbox" name="same_client"> Run on same client
+                  </label>
+                </div>
+              {% endif %}
+              <button type="submit" class="btn btn-default" title="This will stop the current job (if running) and allow it to start it again.">Submit</button>
+            </form>
           </div>
-        </form>
+        </div>
       </div>
     </div>
   {% endif %}


### PR DESCRIPTION
This adds an optional comment field to the cancel and invalidate form.
For PRs, a PR comment can be made with a message of the action along with the user supplied comment.
