### PR TITLE
Add pr_num to the client environment

### DIFF
--- a/ci/client/views.py
+++ b/ci/client/views.py
@@ -148,6 +148,11 @@ def get_job_info(job):
       'config': job.config.name,
       }
 
+  if job.event.pull_request:
+    recipe_env["pr_num"] = str(job.event.pull_request.number)
+  else:
+    recipe_env["pr_num"] = "0"
+
   for env in job.recipe.environment_vars.all():
     recipe_env[env.name] = env.value
 

--- a/client/tests/claim_response.json
+++ b/client/tests/claim_response.json
@@ -9,6 +9,7 @@
       "base_ssh_url": "", 
       "cause": "Pull request", 
       "job_id": 1, 
+      "pr_num": "0",
       "config": "testBuildConfig", 
       "comments_url": "None", 
       "base_repo": "testUser/testRepo", 


### PR DESCRIPTION
This needs to be in place so that we can copy documentation to the public site based on PR number rather than job id.
