### PR TITLE
Add stages to the PR update API.

### DIFF
--- a/ci/PullRequestEvent.py
+++ b/ci/PullRequestEvent.py
@@ -245,6 +245,7 @@ class PullRequestEvent(object):
                 abs_job_url,
                 msg,
                 str(job),
+                server.api().STATUS_JOB_STARTED,
                 )
       else:
         logger.info('Job {}: {}: on {} already exists'.format(job.pk, job, recipe.repository))

--- a/ci/client/UpdateRemoteStatus.py
+++ b/ci/client/UpdateRemoteStatus.py
@@ -47,6 +47,7 @@ def job_started(request, job):
         request.build_absolute_uri(reverse('ci:view_job', args=[job.pk])),
         'Starting',
         str(job),
+        api.STATUS_JOB_STARTED,
         )
 
 def step_start_pr_status(request, step_result, job):
@@ -64,6 +65,9 @@ def step_start_pr_status(request, step_result, job):
   api = server.api()
   status = api.RUNNING
   desc = '({}/{}) {}'.format(step_result.position+1, job.step_results.count(), step_result.name)
+  job_stage = api.STATUS_CONTINUE_RUNNING
+  if step_result.position == 0:
+    job_stage = api.STATUS_START_RUNNING
 
   api.update_pr_status(
       oauth_session,
@@ -73,6 +77,7 @@ def step_start_pr_status(request, step_result, job):
       request.build_absolute_uri(reverse('ci:view_job', args=[job.pk])),
       desc,
       str(job),
+      job_stage,
       )
 
 def job_complete_pr_status(request, job):
@@ -100,6 +105,7 @@ def job_complete_pr_status(request, job):
         request.build_absolute_uri(reverse('ci:view_job', args=[job.pk])),
         msg,
         str(job),
+        api.STATUS_JOB_COMPLETE,
         )
     add_comment(request, oauth_session, user, job)
 
@@ -141,4 +147,5 @@ def step_complete_pr_status(request, step_result, job):
       request.build_absolute_uri(reverse('ci:view_job', args=[job.pk])),
       desc,
       str(job),
+      api.STATUS_CONTINUE_RUNNING,
       )

--- a/ci/git_api.py
+++ b/ci/git_api.py
@@ -29,6 +29,11 @@ class GitAPI(object):
   RUNNING = 4
   CANCELED = 5
 
+  STATUS_JOB_STARTED = 0
+  STATUS_JOB_COMPLETE = 1
+  STATUS_START_RUNNING = 2
+  STATUS_CONTINUE_RUNNING = 3
+
   @abc.abstractmethod
   def sign_in_url(self):
     """
@@ -92,7 +97,7 @@ class GitAPI(object):
     """
 
   @abc.abstractmethod
-  def update_pr_status(self, oauth_session, base, head, state, event_url, description, context):
+  def update_pr_status(self, oauth_session, base, head, state, event_url, description, context, job_stage):
     """
     Update the PR status.
     Input:
@@ -103,6 +108,7 @@ class GitAPI(object):
       event_url: str: URL back to the moosebuild page
       description: str: Description of the update
       context: str: Context for the update
+      job_stage: int: One of the STATUS_* flags
     """
 
   @abc.abstractmethod

--- a/ci/github/api.py
+++ b/ci/github/api.py
@@ -137,7 +137,7 @@ class GitHubAPI(GitAPI):
     session['github_org_repos'] = org_repo
     return org_repo
 
-  def update_pr_status(self, oauth_session, base, head, state, event_url, description, context):
+  def update_pr_status(self, oauth_session, base, head, state, event_url, description, context, job_stage):
     if not settings.REMOTE_UPDATE:
       return
 

--- a/ci/github/tests/test_api.py
+++ b/ci/github/tests/test_api.py
@@ -185,15 +185,21 @@ class Tests(DBTester.DBTester):
     # no state is set so just run for coverage
     settings.REMOTE_UPDATE = True
     mock_post.return_value = self.PrResponse('updated_at')
-    gapi.update_pr_status(auth, ev.base, ev.head, gapi.PENDING, 'event', 'desc', 'context')
+    gapi.update_pr_status(auth, ev.base, ev.head, gapi.PENDING, 'event', 'desc', 'context', gapi.STATUS_JOB_STARTED)
+    self.assertEqual(mock_post.call_count, 1)
+
     mock_post.return_value = self.PrResponse('nothing')
-    gapi.update_pr_status(auth, ev.base, ev.head, gapi.PENDING, 'event', 'desc', 'context')
+    gapi.update_pr_status(auth, ev.base, ev.head, gapi.PENDING, 'event', 'desc', 'context', gapi.STATUS_JOB_STARTED)
+    self.assertEqual(mock_post.call_count, 2)
+
     mock_post.side_effect = Exception('exception')
-    gapi.update_pr_status(auth, ev.base, ev.head, gapi.PENDING, 'event', 'desc', 'context')
+    gapi.update_pr_status(auth, ev.base, ev.head, gapi.PENDING, 'event', 'desc', 'context', gapi.STATUS_JOB_STARTED)
+    self.assertEqual(mock_post.call_count, 3)
 
     # This should just return
     settings.REMOTE_UPDATE = False
-    gapi.update_pr_status(auth, ev.base, ev.head, gapi.PENDING, 'event', 'desc', 'context')
+    gapi.update_pr_status(auth, ev.base, ev.head, gapi.PENDING, 'event', 'desc', 'context', gapi.STATUS_JOB_STARTED)
+    self.assertEqual(mock_post.call_count, 3)
 
   class GetResponse(object):
     def __init__(self, status_code):

--- a/ci/gitlab/api.py
+++ b/ci/gitlab/api.py
@@ -180,11 +180,14 @@ class GitLabAPI(GitAPI):
   def status_url(self, owner, repo, sha):
     return "%s/statuses/%s" % (self.repo_url(owner, repo), sha)
 
-  def update_pr_status(self, oauth_session, base, head, state, event_url, description, context):
+  def update_pr_status(self, oauth_session, base, head, state, event_url, description, context, job_stage):
     """
     This updates the status of a paritcular commit associated with a PR.
     """
     if not settings.REMOTE_UPDATE:
+      return
+
+    if job_stage == self.STATUS_CONTINUE_RUNNING:
       return
 
     data = {

--- a/ci/gitlab/tests/test_api.py
+++ b/ci/gitlab/tests/test_api.py
@@ -296,15 +296,27 @@ class Tests(DBTester.DBTester):
     # no state is set so just run for coverage
     settings.REMOTE_UPDATE = True
     mock_post.return_value = utils.Response(status_code=200, content="some content")
-    gapi.update_pr_status(auth, ev.base, ev.head, gapi.PENDING, 'event', 'desc', 'context')
+    gapi.update_pr_status(auth, ev.base, ev.head, gapi.PENDING, 'event', 'desc', 'context', gapi.STATUS_JOB_STARTED)
+    self.assertEqual(mock_post.call_count, 1)
+
+    gapi.update_pr_status(auth, ev.base, ev.head, gapi.PENDING, 'event', 'desc', 'context', gapi.STATUS_CONTINUE_RUNNING)
+    self.assertEqual(mock_post.call_count, 1)
+
+    gapi.update_pr_status(auth, ev.base, ev.head, gapi.PENDING, 'event', 'desc', 'context', gapi.STATUS_START_RUNNING)
+    self.assertEqual(mock_post.call_count, 2)
+
     mock_post.return_value = utils.Response(status_code=404, content="nothing")
-    gapi.update_pr_status(auth, ev.base, ev.head, gapi.PENDING, 'event', 'desc', 'context')
+    gapi.update_pr_status(auth, ev.base, ev.head, gapi.PENDING, 'event', 'desc', 'context', gapi.STATUS_JOB_STARTED)
+    self.assertEqual(mock_post.call_count, 3)
+
     mock_post.side_effect = Exception('exception')
-    gapi.update_pr_status(auth, ev.base, ev.head, gapi.PENDING, 'event', 'desc', 'context')
+    gapi.update_pr_status(auth, ev.base, ev.head, gapi.PENDING, 'event', 'desc', 'context', gapi.STATUS_JOB_STARTED)
+    self.assertEqual(mock_post.call_count, 4)
 
     # This should just return
     settings.REMOTE_UPDATE = False
-    gapi.update_pr_status(auth, ev.base, ev.head, gapi.PENDING, 'event', 'desc', 'context')
+    gapi.update_pr_status(auth, ev.base, ev.head, gapi.PENDING, 'event', 'desc', 'context', gapi.STATUS_JOB_STARTED)
+    self.assertEqual(mock_post.call_count, 4)
 
   def test_branch_urls(self):
     branch = utils.create_branch(name="test_branch")


### PR DESCRIPTION
Allow the GitServer to determine if they need to post an PR update.
After the recent GitLab update it doesn't seem to like multiple updates on the same job so we need a way for only GitLab to tell if they need to post an update.