### PR TITLE
Provide endpoint for updating the remote job status

### DIFF
--- a/ci/client/urls.py
+++ b/ci/client/urls.py
@@ -24,4 +24,5 @@ urlpatterns = [
   url(r'^start_step_result/(?P<build_key>[0-9]+)/(?P<client_name>[-\w.]+)/(?P<stepresult_id>[0-9]+)/$', views.start_step_result, name='start_step_result'),
   url(r'^complete_step_result/(?P<build_key>[0-9]+)/(?P<client_name>[-\w.]+)/(?P<stepresult_id>[0-9]+)/$', views.complete_step_result, name='complete_step_result'),
   url(r'^ping/(?P<client_name>[-\w.]+)/$', views.client_ping, name='client_ping'),
+  url(r'^update_remote_job_status/(?P<job_id>[0-9]+)/$', views.update_remote_job_status, name='update_remote_job_status'),
   ]

--- a/ci/templates/ci/job_update.html
+++ b/ci/templates/ci/job_update.html
@@ -1,0 +1,34 @@
+{% extends "ci/base.html" %}
+{% comment %}
+  Copyright 2016 Battelle Energy Alliance, LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+{% endcomment %}
+{% block title %}Update job status{% endblock %}
+{% block content %}
+<div class="center">
+    <h2>
+    Update remote git status for {{job}}
+    </h2>
+    <br>
+
+    {% if allowed %}
+        <form action="{% url "ci:client:update_remote_job_status" job.pk %}" method="post">
+            {% csrf_token %}
+            <input type="submit" value="Update" />
+        </form>
+    {% else %}
+        You are not allowed to update the job status.
+    {% endif %}
+</div>
+{% endblock content %}


### PR DESCRIPTION
Just provide a simple form for updating the remote git status of a job.
This can be useful when the job status hasn't been set correctly due to git server timeouts, etc.