### PR TITLE
Have ability to auto cancel jobs on previous push events.

### DIFF
--- a/ci/bitbucket/views.py
+++ b/ci/bitbucket/views.py
@@ -145,7 +145,7 @@ def process_event(request, git_ev):
             git_ev.processed()
             return HttpResponse('OK')
         else:
-            err_str = 'Unknown post to bitbucket hook : %s' % request.body
+            err_str = 'Unknown post to bitbucket hook : %s' % git_ev.dump()
             logger.warning(err_str)
             git_ev.response = "Unknown hook"
             git_ev.processed("Unknown hook", success=False)

--- a/ci/github/views.py
+++ b/ci/github/views.py
@@ -77,6 +77,7 @@ def process_pull_request(git_ev, data):
         pr_event.action = PullRequestEvent.PullRequestEvent.REOPENED
     elif action in ['labeled', 'unlabeled', 'assigned', 'unassigned', 'review_requested', 'review_request_removed']:
         # actions that we don't support
+        git_ev.response = "%s not supported" % action
         return None
     else:
         raise GitException("Pull request %s contained unknown action: %s" % (pr_event.pr_number, action))
@@ -92,6 +93,7 @@ def process_pull_request(git_ev, data):
         if pr_event.title.startswith(prefix):
             # We don't want to test when the PR is marked as a work in progress
             logger.info('Ignoring work in progress PR: {}'.format(pr_event.title))
+            git_ev.response = "Ignoring work in progress"
             return None
 
     pr_event.html_url = pr_data['html_url']
@@ -209,7 +211,7 @@ def process_event(request, git_ev):
             git_ev.processed("Ping test")
             return HttpResponse('OK')
         else:
-            err_str = 'Unknown post to github hook : %s' % request.body
+            err_str = 'Unknown post to github hook : %s' % git_ev.dump()
             logger.warning(err_str)
             git_ev.response = "Unknown hook"
             git_ev.processed("Unknown hook", success=False)

--- a/ci/gitlab/views.py
+++ b/ci/gitlab/views.py
@@ -248,7 +248,7 @@ def process_event(request, git_ev):
                 ev.save(request)
                 git_ev.processed()
                 return HttpResponse('OK')
-        err_str = 'Unknown post to gitlab hook : %s' % request.body
+        err_str = 'Unknown post to gitlab hook : %s' % git_ev.dump()
         logger.warning(err_str)
         git_ev.response = err_str
         git_ev.processed(success=False)

--- a/ci/models.py
+++ b/ci/models.py
@@ -538,6 +538,7 @@ class Recipe(models.Model):
     cause = models.IntegerField(choices=CAUSE_CHOICES, default=CAUSE_PULL_REQUEST)
     build_configs = models.ManyToManyField(BuildConfig)
     auto_authorized = models.ManyToManyField(GitUser, related_name='auto_authorized', blank=True)
+    auto_cancel_on_push = models.BooleanField(default=False)
     # depends_on depend on other recipes which means that it isn't symmetrical
     depends_on = models.ManyToManyField('Recipe', symmetrical=False, blank=True)
     automatic = models.IntegerField(choices=AUTO_CHOICES, default=FULL_AUTO)

--- a/ci/recipe/RecipeCreator.py
+++ b/ci/recipe/RecipeCreator.py
@@ -298,6 +298,7 @@ class RecipeCreator(object):
             recipe.priority = recipe_dict["priority_release"]
         elif cause in [models.Recipe.CAUSE_PUSH, models.Recipe.CAUSE_PUSH_ALT]:
             recipe.priority = recipe_dict["priority_push"]
+            recipe.auto_cancel_on_push = recipe_dict["auto_cancel_on_new_push"]
 
         autos = {"automatic": models.Recipe.FULL_AUTO, "manual": models.Recipe.MANUAL, "authorized": models.Recipe.AUTO_FOR_AUTHORIZED}
         recipe.automatic = autos[recipe_dict["automatic"]]

--- a/ci/recipe/RecipeReader.py
+++ b/ci/recipe/RecipeReader.py
@@ -296,6 +296,7 @@ class RecipeReader(object):
         recipe["priority_pull_request"] = self.get_option("Main", "priority_pull_request", 0)
         recipe["trigger_push"] = self.get_option("Main", "trigger_push", False)
         recipe["trigger_push_branch"] = self.get_option("Main", "trigger_push_branch", "")
+        recipe["auto_cancel_on_new_push"] = self.get_option("Main", "auto_cancel_on_new_push", False)
         recipe["trigger_release"] = self.get_option("Main", "trigger_release", False)
         recipe["priority_release"] = self.get_option("Main", "priorty_release", 0)
         recipe["priority_push"] = self.get_option("Main", "priority_push", 0)

--- a/ci/recipe/tests/recipe_all.cfg
+++ b/ci/recipe/tests/recipe_all.cfg
@@ -11,6 +11,7 @@ trigger_push_branch = devel
 priority_push = 1
 trigger_pull_request = true
 priority_pull_request = 2
+auto_cancel_on_new_push = true
 trigger_manual = true
 trigger_manual_branch = devel
 priority_manual = 3

--- a/ci/recipe/tests/test_RecipeCreator.py
+++ b/ci/recipe/tests/test_RecipeCreator.py
@@ -100,6 +100,8 @@ class Tests(RecipeTester.RecipeTester):
     def test_load_deps_ok(self):
         # OK. New idaholab/moose/devel
         self.create_valid_with_check()
+        r = models.Recipe.objects.filter(auto_cancel_on_push=True)
+        self.assertEqual(r.count(), 1)
 
     def test_no_change(self):
         # Start off with valid recipes


### PR DESCRIPTION
This can be used to auto cancel certain jobs when, for example,
multiple merges to master happen in quick succession and we don't
want to run things like documentation, update submodules, etc.