### PR TITLE
Change location of the client PID file from /tmp to $HOME.

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import argparse
-import sys
+import sys, os
 import BaseClient
 from DaemonLite import DaemonLite
 
@@ -26,7 +26,7 @@ class ClientDaemon(DaemonLite):
         self.client = client
 
 def call_daemon(client, cmd):
-    pfile = '/tmp/client_%s.pid' % client.client_info["client_name"]
+    pfile = os.path.join(os.environ["HOME"], 'civet_client_%s.pid' % client.client_info["client_name"])
     client_daemon = ClientDaemon(pfile, stdout=client.client_info["log_file"], stderr=client.client_info["log_file"])
     client_daemon.set_client(client)
     if cmd == 'restart':

--- a/client/inl_client.py
+++ b/client/inl_client.py
@@ -61,7 +61,7 @@ class ClientDaemon(DaemonLite):
         self.client = client
 
 def call_daemon(client, cmd):
-    pfile = '/tmp/client_%s.pid' % client.client_info["client_name"]
+    pfile = os.path.join(os.environ["HOME"], 'civet_client_%s.pid' % client.client_info["client_name"])
     client_daemon = ClientDaemon(pfile, stdout=client.client_info["log_file"], stderr=client.client_info["log_file"])
     client_daemon.set_client(client)
     if cmd == 'restart':

--- a/client/scripts/control.sh
+++ b/client/scripts/control.sh
@@ -51,7 +51,7 @@ function control()
 function get_pid()
 {
   local client_num=${1:?"Need a client number"}
-  local pid_file="/tmp/client_${HOSTNAME}_${client_num}.pid"
+  local pid_file="$HOME/civet_client_${HOSTNAME}_${client_num}.pid"
   if [ -e "$pid_file" ]; then
     cat "$pid_file"
   fi


### PR DESCRIPTION
For long running clients, when keeping it in /tmp, it can
be removed by the system cleanup of /tmp.