### PR TITLE
Don't include build config on PR status messages

### DIFF
--- a/ci/PullRequestEvent.py
+++ b/ci/PullRequestEvent.py
@@ -256,7 +256,7 @@ class PullRequestEvent(object):
                         git_status,
                         abs_job_url,
                         msg,
-                        str(job),
+                        job.unique_name(),
                         server.api().STATUS_JOB_STARTED,
                         )
             else:

--- a/ci/client/UpdateRemoteStatus.py
+++ b/ci/client/UpdateRemoteStatus.py
@@ -25,8 +25,8 @@ def add_comment(request, oauth_session, user, job):
         return
     if not job.event.comments_url:
         return
-    comment = 'Testing {}\n\n{} {}: **{}**\n'.format(job.event.head.sha, job.recipe.name, job.config, job.status_str())
     abs_job_url = request.build_absolute_uri(reverse('ci:view_job', args=[job.pk]))
+    comment = 'Testing {}\n\n[{}]({}) : **{}**\n'.format(job.event.head.sha, job.unique_name(), abs_job_url, job.status_str())
     comment += '\nView the results [here]({}).\n'.format(abs_job_url)
     user.server.api().pr_job_status_comment(oauth_session, job.event.comments_url, comment)
 
@@ -46,7 +46,7 @@ def job_started(request, job):
             api.PENDING,
             request.build_absolute_uri(reverse('ci:view_job', args=[job.pk])),
             'Starting',
-            str(job),
+            job.unique_name(),
             api.STATUS_JOB_STARTED,
             )
 
@@ -76,7 +76,7 @@ def step_start_pr_status(request, step_result, job):
         status,
         request.build_absolute_uri(reverse('ci:view_job', args=[job.pk])),
         desc,
-        str(job),
+        job.unique_name(),
         job_stage,
         )
 
@@ -104,7 +104,7 @@ def job_complete_pr_status(request, job):
             status,
             request.build_absolute_uri(reverse('ci:view_job', args=[job.pk])),
             msg,
-            str(job),
+            job.unique_name(),
             api.STATUS_JOB_COMPLETE,
             )
         add_comment(request, oauth_session, user, job)
@@ -125,6 +125,6 @@ def job_wont_run(request, job):
             api.CANCELED,
             request.build_absolute_uri(reverse('ci:view_job', args=[job.pk])),
             "Won't run due to failed dependencies",
-            str(job),
+            job.unique_name(),
             api.STATUS_JOB_COMPLETE,
             )

--- a/ci/client/views.py
+++ b/ci/client/views.py
@@ -340,7 +340,7 @@ def job_finished(request, build_key, client_name, job_id):
     UpdateRemoteStatus.job_complete_pr_status(request, job)
 
     ParseOutput.set_job_info(job)
-    ProcessCommands.process_commands(job)
+    ProcessCommands.process_commands(request, job)
 
     # now check if all configs are finished
     all_complete = True


### PR DESCRIPTION
Unless the name isn't unique (ie, we have "Test:linux-gnu" and "Test:mac-clang".

Also, add links to the job page when posting comments.