### PR TITLE
If the JobRunner has errors then exit the client.

### DIFF
--- a/ci/client/views.py
+++ b/ci/client/views.py
@@ -323,6 +323,10 @@ def job_finished(request, build_key, client_name, job_id):
 
     job.seconds = timedelta(seconds=data['seconds'])
     job.complete = data['complete']
+    # In addition to the server sending the cancel command to the client, this
+    # can also be set by the client if something went wrong
+    if data.get("canceled", False):
+        job.status = models.JobStatus.CANCELED
     job.save()
 
     update_status(job)

--- a/client/BaseClient.py
+++ b/client/BaseClient.py
@@ -76,6 +76,7 @@ class BaseClient(object):
     def __init__(self, client_info):
         self.client_info = client_info
         self.command_q = Queue()
+        self.runner_error = False
 
         if self.client_info["log_file"]:
             self.set_log_file(self.client_info["log_file"])
@@ -168,6 +169,7 @@ class BaseClient(object):
         logger.info("Joining ServerUpdater")
         updater_thread.join()
         self.command_q.queue.clear()
+        self.runner_error = runner.error
 
     def run(self):
         """
@@ -190,6 +192,11 @@ class BaseClient(object):
             if self.cancel_signal.triggered or self.graceful_signal.triggered:
                 logger.info("Received signal...exiting")
                 break
+
+            if self.runner_error:
+                logger.info("Error occurred in runner...exiting")
+                break
+
             if self.client_info["single_shot"]:
                 break
 

--- a/client/INLClient.py
+++ b/client/INLClient.py
@@ -103,16 +103,20 @@ class INLClient(BaseClient.BaseClient):
         while True:
             ran_job = False
             for server in settings.SERVERS:
-                if self.cancel_signal.triggered or self.graceful_signal.triggered:
+                if self.cancel_signal.triggered or self.graceful_signal.triggered or self.runner_error:
                     break
                 try:
                     if self.check_server(server):
                         ran_job = True
                 except Exception as e:
                     logger.debug("Error: %s" % traceback.format_exc(e))
+                    break
 
             if self.cancel_signal.triggered or self.graceful_signal.triggered:
                 logger.info("Received signal...exiting")
+                break
+            if self.runner_error:
+                logger.info("Error in runner...exiting")
                 break
             if single:
                 break

--- a/client/tests/test_BaseClient_live.py
+++ b/client/tests/test_BaseClient_live.py
@@ -139,3 +139,12 @@ class Tests(LiveClientTester.LiveClientTester):
         self.set_counts()
         c.run()
         self.compare_counts()
+
+    @patch.object(JobGetter.JobGetter, 'find_job')
+    def test_runner_error(self, mock_getter):
+        mock_getter.return_value = None
+        c, job = self.create_client_and_job("JobError")
+        self.set_counts()
+        c.runner_error = True
+        c.run()
+        self.compare_counts()

--- a/client/tests/test_INLClient_live.py
+++ b/client/tests/test_INLClient_live.py
@@ -141,3 +141,12 @@ class Tests(LiveClientTester.LiveClientTester):
         self.set_counts()
         c.check_server(settings.SERVERS[0])
         self.compare_counts(num_clients=1)
+
+    @patch.object(JobGetter, 'find_job')
+    def test_runner_error(self, mock_getter):
+        mock_getter.return_value = None
+        c, job = self.create_client_and_job("JobError")
+        self.set_counts()
+        c.runner_error = True
+        c.run()
+        self.compare_counts()


### PR DESCRIPTION
This was primarily put in place to try to catch
the out of disk space error so that the client doesn't
keep trying new jobs and then failing immediately.