### PR TITLE
Set job status to ACTIVATION_REQUIRED for non active jobs.

### DIFF
--- a/ci/ManualEvent.py
+++ b/ci/ManualEvent.py
@@ -102,7 +102,10 @@ class ManualEvent(object):
                     job.ready = False
                     job.complete = False
                     job.active = r.active
-                    job.status = models.JobStatus.NOT_STARTED
+                    if job.active:
+                        job.status = models.JobStatus.NOT_STARTED
+                    else:
+                        job.status = models.JobStatus.ACTIVATION_REQUIRED
                     job.save()
                     logger.info('Created job {}: {} on {}'.format(job.pk, job, r.repository))
 

--- a/ci/PullRequestEvent.py
+++ b/ci/PullRequestEvent.py
@@ -239,7 +239,10 @@ class PullRequestEvent(object):
                 job.active = active
                 job.ready = False
                 job.complete = False
-                job.status = models.JobStatus.NOT_STARTED
+                if job.active:
+                    job.status = models.JobStatus.NOT_STARTED
+                else:
+                    job.status = models.JobStatus.ACTIVATION_REQUIRED
                 job.save()
                 logger.info('Created job {}: {}: on {}'.format(job.pk, job, recipe.repository))
 

--- a/ci/PushEvent.py
+++ b/ci/PushEvent.py
@@ -120,6 +120,7 @@ class PushEvent(object):
                     job.active = True
                     if r.automatic == models.Recipe.MANUAL:
                         job.active = False
+                        job.status = models.JobStatus.ACTIVATION_REQUIRED
                     job.ready = False
                     job.complete = False
                     job.save()

--- a/ci/client/UpdateRemoteStatus.py
+++ b/ci/client/UpdateRemoteStatus.py
@@ -198,7 +198,7 @@ def job_complete(request, job):
     job_complete_pr_status(job_url, job)
 
     ParseOutput.set_job_info(job)
-    ProcessCommands.process_commands(request, job)
+    ProcessCommands.process_commands(job_url, job)
 
     all_done = job.event.set_complete_if_done()
 

--- a/ci/client/tests/test_ProcessCommands.py
+++ b/ci/client/tests/test_ProcessCommands.py
@@ -195,37 +195,37 @@ class Tests(ClientTester.ClientTester):
         ev.cause = models.Event.PUSH
         ev.save()
         step = job.recipe.steps.first()
-        request = self.factory.get('/')
         # if not a PULL_REQUEST, it should just return
-        ProcessCommands.process_commands(request, job)
+        url = "foo"
+        ProcessCommands.process_commands(url, job)
         self.assertEqual(mock_post.call_count, 0)
         self.assertEqual(mock_submodule.call_count, 0)
 
         ev.cause = models.Event.PULL_REQUEST
         ev.save()
         # No commands in the environment
-        ProcessCommands.process_commands(request, job)
+        ProcessCommands.process_commands(url, job)
         self.assertEqual(mock_post.call_count, 0)
         self.assertEqual(mock_submodule.call_count, 0)
 
         utils.create_step_environment(name="CIVET_SERVER_POST_ON_SUBMODULE_UPDATE", value="1", step=step)
-        ProcessCommands.process_commands(request, job)
+        ProcessCommands.process_commands(url, job)
         self.assertEqual(mock_post.call_count, 0)
         self.assertEqual(mock_submodule.call_count, 1)
 
         step.step_environment.all().delete()
         utils.create_step_environment(name="CIVET_SERVER_POST_COMMENT", value="1", step=step)
-        ProcessCommands.process_commands(request, job)
+        ProcessCommands.process_commands(url, job)
         self.assertEqual(mock_post.call_count, 1)
         self.assertEqual(mock_submodule.call_count, 1)
 
         utils.create_step_environment(name="CIVET_SERVER_POST_REMOVE_OLD", value="1", step=step)
-        ProcessCommands.process_commands(request, job)
+        ProcessCommands.process_commands(url, job)
         self.assertEqual(mock_post.call_count, 2)
         self.assertEqual(mock_submodule.call_count, 1)
 
         utils.create_step_environment(name="CIVET_SERVER_POST_EDIT_EXISTING", value="1", step=step)
-        ProcessCommands.process_commands(request, job)
+        ProcessCommands.process_commands(url, job)
         self.assertEqual(mock_post.call_count, 3)
         self.assertEqual(mock_submodule.call_count, 1)
 
@@ -242,17 +242,17 @@ class Tests(ClientTester.ClientTester):
         ev.comments_url = "some url"
         ev.save()
         step = job.recipe.steps.first()
-        request = self.factory.get('/')
+        url = "foo"
 
         utils.create_step_environment(name="CIVET_SERVER_POST_ON_SUBMODULE_UPDATE", value="1", step=step)
-        ProcessCommands.process_commands(request, job)
+        ProcessCommands.process_commands(url, job)
 
         step.step_environment.all().delete()
         utils.create_step_environment(name="CIVET_SERVER_POST_COMMENT", value="1", step=step)
-        ProcessCommands.process_commands(request, job)
+        ProcessCommands.process_commands(url, job)
 
         utils.create_step_environment(name="CIVET_SERVER_POST_REMOVE_OLD", value="1", step=step)
-        ProcessCommands.process_commands(request, job)
+        ProcessCommands.process_commands(url, job)
 
         utils.create_step_environment(name="CIVET_SERVER_POST_EDIT_EXISTING", value="1", step=step)
-        ProcessCommands.process_commands(request, job)
+        ProcessCommands.process_commands(url, job)

--- a/ci/models.py
+++ b/ci/models.py
@@ -613,9 +613,8 @@ class Event(models.Model):
         Jobs are checked to see if dependencies are met and
         if so, then they are marked as ready.
         """
-        completed_jobs = self.jobs.filter(complete=True, active=True)
 
-        if self.jobs.filter(active=True).count() == completed_jobs.count():
+        if self.check_done():
             self.complete = True
             self.save()
             logger.info('Event {}: {} complete'.format(self.pk, self))

--- a/ci/tests/test_event.py
+++ b/ci/tests/test_event.py
@@ -64,7 +64,7 @@ class Tests(DBTester.DBTester):
 
         self.set_counts()
         self.job0.event.make_jobs_ready()
-        self.compare_counts()
+        self.compare_counts(num_events_completed=True) # None of the other jobs can run so event is complete
         self.job_compare()
 
     def test_make_jobs_ready_first_passed(self):


### PR DESCRIPTION
Fix call to process_commands that didn't pass in a URL.