### PR TITLE
Add a sync_open_prs management command.

### DIFF
--- a/ci/bitbucket/api.py
+++ b/ci/bitbucket/api.py
@@ -255,3 +255,17 @@ class BitBucketAPI(GitAPI):
 
     def edit_pr_comment(self, oauth, comment, msg):
         logger.warning("FIXME: BitBucket function not implemented: edit_pr_comment")
+
+    def get_open_prs(self, oauth_session, owner, repo):
+        url = "%s/repositories/%s/%s/pullrequests" % (self._api2_url, owner, repo)
+        params = {"state": "OPEN"}
+        try:
+            response = oauth_session.get(url, params=params)
+            data = self.get_all_pages(oauth_session, response)
+            response.raise_for_status()
+            open_prs = []
+            for pr in data.get("values", []):
+                open_prs.append({"number": pr["id"], "title": pr["title"], "html_url": pr["links"]["html"]})
+            return open_prs
+        except Exception as e:
+            logger.warning("Failed to get open PRs for %s/%s at URL: %s\nError: %s" % (owner, repo, url, e))

--- a/ci/bitbucket/tests/test_api.py
+++ b/ci/bitbucket/tests/test_api.py
@@ -288,3 +288,16 @@ class Tests(TestCase):
         self.gapi.remove_pr_comment(None, None)
         self.gapi.edit_pr_comment(None, None, None)
         self.gapi.is_member(None, None, None)
+
+    @patch.object(OAuth2Session, 'get')
+    def test_get_open_prs(self, mock_get):
+        repo = utils.create_repo()
+        pr0 = {"title": "some title", "id": 123, "links": {"html": "some url"}}
+        pr0_ret = {"title": "some title", "number": 123, "html_url": "some url"}
+        mock_get.return_value = utils.Response({"values":[pr0]})
+        prs = self.gapi.get_open_prs(self.auth, repo.user.name, repo.name)
+        self.assertEquals([pr0_ret], prs)
+
+        mock_get.side_effect = Exception("BAM!")
+        prs = self.gapi.get_open_prs(self.auth, repo.user.name, repo.name)
+        self.assertEquals(prs, None)

--- a/ci/git_api.py
+++ b/ci/git_api.py
@@ -280,3 +280,19 @@ class GitAPI(object):
           team[str]: Name of the team/org/group
           user[models.GitUser]: User to check
         """
+
+    @abc.abstractmethod
+    def get_open_prs(self, oauth, owner, repo):
+        """
+        Get a list of open PRs for a repo
+        Input:
+          auth_session[requests_oauthlib.OAuth2Session]: for the user with a token
+          owner[str]: owner name
+          repo[str]: repo name
+        Return:
+            list[dict]: None can be returned on error.
+            Each dict will have the following key/value pairs:
+                number[int]: PR number
+                title[str]: Title of the PR
+                html_url[str]: URL to the PR
+        """

--- a/ci/github/tests/test_api.py
+++ b/ci/github/tests/test_api.py
@@ -601,3 +601,15 @@ class Tests(DBTester.DBTester):
         mock_get.side_effect = [team_id_response, team_data_response]
         is_member = self.gapi.is_member(self.auth, "bar/foo foo", user)
         self.assertFalse(is_member)
+
+    @patch.object(OAuth2Session, 'get')
+    def test_get_open_prs(self, mock_get):
+        repo = test_utils.create_repo()
+        pr0 = {"title": "some title", "number": 123, "html_url": "some url"}
+        mock_get.return_value = test_utils.Response([pr0])
+        prs = self.gapi.get_open_prs(self.auth, repo.user.name, repo.name)
+        self.assertEquals([pr0], prs)
+
+        mock_get.side_effect = Exception("BAM!")
+        prs = self.gapi.get_open_prs(self.auth, repo.user.name, repo.name)
+        self.assertEquals(prs, None)

--- a/ci/gitlab/api.py
+++ b/ci/gitlab/api.py
@@ -491,3 +491,18 @@ class GitLabAPI(GitAPI):
             return True
         token = self.get_token(oauth)
         return self.is_group_member(oauth, token, team, user.name)
+
+    def get_open_prs(self, oauth, owner, repo):
+        url = "%s/merge_requests" % self.repo_url(owner, repo)
+        params = {"state": "opened"}
+        try:
+            token = self.get_token(oauth)
+            response = self.get(url, token, params)
+            response.raise_for_status()
+            data = self.get_all_pages(oauth, response)
+            open_prs = []
+            for pr in data:
+                open_prs.append({"number": pr["iid"], "title": pr["title"], "html_url": pr["web_url"]})
+            return open_prs
+        except Exception as e:
+            logger.warning("Failed to get open PRs for %s/%s at URL: %s\nError: %s" % (owner, repo, url, e))

--- a/ci/gitlab/tests/test_api.py
+++ b/ci/gitlab/tests/test_api.py
@@ -458,3 +458,16 @@ class Tests(DBTester.DBTester):
         gapi = api.GitLabAPI()
         gapi.add_pr_label(None, None, None, None)
         gapi.remove_pr_label(None, None, None, None)
+
+    @patch.object(requests, 'get')
+    def test_get_open_prs(self, mock_get):
+        repo = utils.create_repo()
+        pr0 = {"title": "some title", "iid": 123, "web_url": "some url"}
+        pr0_ret = {"title": "some title", "number": 123, "html_url": "some url"}
+        mock_get.return_value = utils.Response([pr0])
+        prs = self.gapi.get_open_prs(self.auth, repo.user.name, repo.name)
+        self.assertEquals([pr0_ret], prs)
+
+        mock_get.side_effect = Exception("BAM!")
+        prs = self.gapi.get_open_prs(self.auth, repo.user.name, repo.name)
+        self.assertEquals(prs, None)

--- a/ci/management/commands/sync_open_prs.py
+++ b/ci/management/commands/sync_open_prs.py
@@ -1,0 +1,57 @@
+from django.core.management.base import BaseCommand
+from ci import models
+
+class Command(BaseCommand):
+    help = 'Close CIVET open PRs that the server says are closed'
+    def add_arguments(self, parser):
+        parser.add_argument('--dryrun', default=False, action='store_true', help="Don't make any changes, just report what would have happened")
+        parser.add_argument('--repo', help="Limit sync to this repository")
+
+    def _get_repos(self, repo):
+        if not repo:
+            repo_q = models.Repository.objects.filter(active=True).exclude(recipes=None)
+        else:
+            r = repo.split("/")
+            if len(r) != 2:
+                raise Exception("Bad repo format. Should be <owner>/<repo_name>")
+            repo_q = models.Repository.objects.filter(user__name=r[0], name=r[1], active=True)
+        return repo_q
+
+    def handle(self, *args, **options):
+        dryrun = options["dryrun"]
+        repo_q = self._get_repos(options["repo"])
+        self._sync_open_prs(repo_q, dryrun)
+
+    def _sync_open_prs(self, q, dryrun):
+        open_on_server_no_civet = []
+        for repo in q.all():
+            build_user = repo.recipes.last().build_user
+            open_prs = repo.get_open_prs_from_server(build_user)
+            if open_prs is None:
+                self.stdout.write("Error getting open PRs for %s. Skipping." % repo)
+                continue
+
+            pr_q = models.PullRequest.objects.filter(closed=False, repository=repo)
+            server_pr_ids = [pr["number"] for pr in open_prs]
+            civet_pr_ids = []
+            # Find PRs that CIVET has open but the doesn't have
+            # Close them in CIVET if this isn't a dryrun
+            for civet_pr in pr_q.all():
+                civet_pr_ids.append(civet_pr.number)
+                if civet_pr.number not in server_pr_ids:
+                    if not dryrun:
+                        self.stdout.write("Closing on CIVET: %s #%s: %s" % (repo, civet_pr.number, civet_pr.title))
+                        civet_pr.closed = True
+                        civet_pr.save()
+                    else:
+                        self.stdout.write("DRYRUN: Would close on CIVET: %s #%s: %s" % (repo, civet_pr.number, civet_pr.title))
+            # Keep a list of PRs that the Git Server has open but CIVET does not
+            for pr in open_prs:
+                if pr["number"] not in civet_pr_ids:
+                    pr["repo"] = repo
+                    open_on_server_no_civet.append(pr)
+
+        if open_on_server_no_civet:
+            self.stdout.write("\n%s\nPRs open on server but not open on CIVET:" % ("-"*50))
+            for pr in open_on_server_no_civet:
+                self.stdout.write("\t%s #%s: %s\t%s" % (pr["repo"], pr["number"], pr["title"], pr["html_url"]))

--- a/ci/models.py
+++ b/ci/models.py
@@ -197,6 +197,11 @@ class Repository(models.Model):
         server = self.user.server
         return server.api().repo_html_url(self.user.name, self.name)
 
+    def get_open_prs_from_server(self, access_user):
+        server = self.user.server
+        auth = access_user.start_session()
+        return server.api().get_open_prs(auth, self.user.name, self.name)
+
     class Meta:
         unique_together = ['user', 'name']
 

--- a/ci/templates/ci/base.html
+++ b/ci/templates/ci/base.html
@@ -189,7 +189,6 @@
   </nav>
 
   <div class="container">
-    <!-- Main component for a primary marketing message or call to action -->
     {% block messages %}
       {% if messages %}
         {% for message in messages %}
@@ -206,13 +205,10 @@
     <div id="content">
       {% block content %}{% endblock %}
     </div>
-  </div> <!-- /container -->
+  </div>
 
 
 {% block end_scripts %}
-  <!-- Bootstrap core JavaScript
-  ================================================== -->
-  <!-- Placed at the end of the document so the pages load faster -->
   <script src="{% static "third_party/bootstrap-3.3.6/js/bootstrap.min.js" %}"></script>
 {% endblock %}
 </body>

--- a/ci/tests/test_commands.py
+++ b/ci/tests/test_commands.py
@@ -1,0 +1,131 @@
+# Copyright 2016 Battelle Energy Alliance, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from django.core import management
+from django.utils.six import StringIO
+from django.test import override_settings
+from django.conf import settings
+from mock import patch
+from ci import models
+from . import utils
+from ci.github import api
+import DBTester
+
+@override_settings(INSTALLED_GITSERVERS=[settings.GITSERVER_GITHUB])
+class Tests(DBTester.DBTester):
+    def setUp(self):
+        super(Tests, self).setUp()
+        self.create_default_recipes()
+
+    @patch.object(api.GitHubAPI, 'get_open_prs')
+    def test_sync_open_prs(self, mock_open_prs):
+        mock_open_prs.return_value = []
+
+        out = StringIO()
+        management.call_command("sync_open_prs", stdout=out)
+        self.assertEqual("", out.getvalue())
+
+        r = models.Recipe.objects.first()
+        repo = r.repository
+        repo.active = True
+        repo.save()
+
+        pr = utils.create_pr(title="TESTPR")
+        pr.closed = False
+        pr.save()
+
+        # A PR with recipe but its repository isn't active
+        out = StringIO()
+        management.call_command("sync_open_prs", stdout=out)
+        self.assertEqual("", out.getvalue())
+
+        pr.repository = repo
+        pr.save()
+
+        # A PR with a good repo, should be closed
+        out = StringIO()
+        management.call_command("sync_open_prs", stdout=out)
+        self.assertIn(pr.title, out.getvalue())
+        self.assertIn(str(pr.number), out.getvalue())
+        self.assertIn(str(pr.repository), out.getvalue())
+        pr.refresh_from_db()
+        self.assertEqual(pr.closed, True)
+
+        # Try to sync a specific repository that exists
+        out = StringIO()
+        pr.closed = False
+        pr.save()
+        management.call_command("sync_open_prs", "--dryrun", "--repo", str(repo), stdout=out)
+        self.assertIn(pr.title, out.getvalue())
+        self.assertIn(str(pr.number), out.getvalue())
+        self.assertIn(str(pr.repository), out.getvalue())
+        pr.refresh_from_db()
+        self.assertEqual(pr.closed, False)
+
+        # Try to sync a specific repository that exists
+        out = StringIO()
+        management.call_command("sync_open_prs", "--repo", str(repo), stdout=out)
+        self.assertIn(pr.title, out.getvalue())
+        self.assertIn(str(pr.number), out.getvalue())
+        self.assertIn(str(pr.repository), out.getvalue())
+        pr.refresh_from_db()
+        self.assertEqual(pr.closed, True)
+
+        # Make sure dry run doesn't change anything
+        out = StringIO()
+        pr.closed = False
+        pr.save()
+        management.call_command("sync_open_prs", "--dryrun", stdout=out)
+        self.assertIn(pr.title, out.getvalue())
+        self.assertIn(str(pr.number), out.getvalue())
+        self.assertIn(str(pr.repository), out.getvalue())
+        pr.refresh_from_db()
+        self.assertEqual(pr.closed, False)
+
+        git_response = [
+                {"number": pr.number,
+                    "title": "PR 1",
+                    "html_url": "first_url",
+                },
+                {"number": pr.number + 1,
+                    "title": "PR 2",
+                    "html_url": "second_url",
+                },
+                ]
+        mock_open_prs.return_value = git_response
+
+        # Server has other PRs that CIVET doesn't have
+        out = StringIO()
+        management.call_command("sync_open_prs", "--dryrun", stdout=out)
+        self.assertNotIn(pr.title, out.getvalue())
+        self.assertNotIn("#%s" % pr.number, out.getvalue())
+        self.assertIn("PRs open on server but not open on CIVET", out.getvalue())
+        self.assertIn("PR 2", out.getvalue())
+        self.assertIn("second_url", out.getvalue())
+        self.assertIn("#%s" % (pr.number+1), out.getvalue())
+        pr.refresh_from_db()
+        self.assertEqual(pr.closed, False)
+
+        # Try to sync a specific repository that doesn't exist
+        out = StringIO()
+        management.call_command("sync_open_prs", "--dryrun", "--repo", "foo/bar", stdout=out)
+        self.assertEqual("", out.getvalue())
+
+        # If the git server encounters an error then it shouldn't do anything
+        mock_open_prs.return_value = None
+        out = StringIO()
+        management.call_command("sync_open_prs", stdout=out)
+        self.assertIn("Error getting open PRs for %s" % repo, out.getvalue())
+        pr.refresh_from_db()
+        self.assertEqual(pr.closed, False)

--- a/ci/tests/test_views.py
+++ b/ci/tests/test_views.py
@@ -1157,9 +1157,6 @@ class Tests(DBTester.DBTester):
         self.assertEqual(ge.success, True)
 
     def test_view_user(self):
-        """
-        testing ci:view_user
-        """
         user = utils.create_user()
         url = reverse('ci:view_user', args=["no_exist"])
         response = self.client.get(url)


### PR DESCRIPTION
Sometimes the PRs the git server and the PRs CIVET
thinks are open get out of sync due to failed events.
This automatically closes PRs that CIVET thinks
are open but have been closed on the Git server.
Also reports any open PRs on the Git server
that CIVET doesn't have open.
Added as a management command as this is mainly for admins.
For usage:
`./manage.py sync_open_prs --help`
Of interest is the `--dryrun` option that will just report what would have been done.

closes #331