### PR TITLE
Truncate long words in event description because it causes

### DIFF
--- a/ci/EventsStatus.py
+++ b/ci/EventsStatus.py
@@ -91,7 +91,15 @@ def events_filter_by_repo(pks, limit=30, last_modified=None):
 def clean_str_for_format(s):
     new_s = s.replace("{", "{{")
     new_s = new_s.replace("}", "}}")
-    return new_s
+    words = []
+    # Really long words cause havoc on the table of events.
+    # We could try to insert <wbr> so the browser breaks it
+    # up but truncating is much simpler.
+    for s in new_s.split():
+        if len(s) > 20:
+            s = "%s..." % s[:17]
+        words.append(s)
+    return " ".join(words)
 
 def chunks(l, n):
     for i in xrange(0, len(l), n):
@@ -167,7 +175,7 @@ def events_info(events, last_modified=None, events_url=False):
         else:
             event_desc = format_html(u'{} <a href="{}">{}', repo_link, event_url, ev.base.branch.name)
             if ev.description:
-                event_desc = format_html(u'{} : {}', mark_safe(event_desc), ev.description)
+                event_desc = format_html(u'{} : {}', mark_safe(event_desc), clean_str_for_format(ev.description))
             event_desc += '</a>'
 
         info = { 'id': ev.pk,

--- a/ci/tests/test_EventsStatus.py
+++ b/ci/tests/test_EventsStatus.py
@@ -34,7 +34,7 @@ class Tests(DBTester.DBTester):
         merge = utils.create_recipe(name="Merge", user=self.build_user, repo=self.repo)
         merge.depends_on.add(test)
         merge.depends_on.add(test1)
-        pr = utils.create_pr(title="{a, b} & <c> …", repo=self.repo)
+        pr = utils.create_pr(title="{a, b} & <c> … somereallylongwordthatshouldgettruncated", repo=self.repo)
         pr.username = 'pr_user'
         pr.save()
         for commit in ['1234', '2345', '3456']:
@@ -45,7 +45,19 @@ class Tests(DBTester.DBTester):
             utils.create_job(recipe=test, event=e, user=self.build_user)
             utils.create_job(recipe=test1, event=e, user=self.build_user)
             utils.create_job(recipe=merge, event=e, user=self.build_user)
-        self.compare_counts(recipes=4, deps=4, current=4, jobs=12, active=12, num_pr_recipes=4, events=3, users=2, repos=1, branches=1, commits=3, prs=1)
+
+        self.compare_counts(recipes=4,
+                deps=4,
+                current=4,
+                jobs=12,
+                active=12,
+                num_pr_recipes=4,
+                events=3,
+                users=2,
+                repos=1,
+                branches=1,
+                commits=3,
+                prs=1)
 
     def test_get_default_events_query(self):
         self.create_events()


### PR DESCRIPTION
problems with the event table.