### PR TITLE
Use the mingw64_runcmd.bat in our scripts directory.

### DIFF
--- a/client/JobRunner.py
+++ b/client/JobRunner.py
@@ -369,7 +369,7 @@ class JobRunner(object):
         Return:
           subprocess.Popen that was created
         """
-        exec_cmd = 'C:\msys64\mingw64_runcmd.bat'
+        exec_cmd = os.path.join(os.path.dirname(__file__), "scripts", "mingw64_runcmd.bat")
         proc = subprocess.Popen(
             [exec_cmd, script_name],
             env=env,

--- a/client/scripts/mingw64_runcmd.bat
+++ b/client/scripts/mingw64_runcmd.bat
@@ -27,6 +27,6 @@ set MSYSTEM=MINGW64
 rem Run the provided command in a new shell (don't use the START
 rem   command, which creates a new process instead of waiting for
 rem   execution to finish).
-%WD%sh --login %*
+%WD%bash %*
 
 :EOF


### PR DESCRIPTION
mingw64_runcmd.bat calls bash directly, without --login,
so that it sources ~/.bashrc

@derekstucki Where there any other changes to mingw64_runcmd.bat that you needed to make?
I assume that mingw64_runcmd.bat doesn't need to be in `C:\msys64`, so we might as well use the one in the civet repo. Does this change work for you?