### PR TITLE
Make python3 compatible 

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -17,3 +17,4 @@ concurrency = multiprocessing
 exclude_lines =
   if __name__ == '__main__':
   if __name__ == "__main__":
+  except ImportError

--- a/ci/DebugViews.py
+++ b/ci/DebugViews.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.http import HttpResponse, Http404
 from django.conf import settings
 from django.shortcuts import redirect, get_object_or_404

--- a/ci/EventsStatus.py
+++ b/ci/EventsStatus.py
@@ -102,7 +102,7 @@ def clean_str_for_format(s):
     return " ".join(words)
 
 def chunks(l, n):
-    for i in xrange(0, len(l), n):
+    for i in range(0, len(l), n):
         yield l[i:i+n]
 
 def multiline_events_info(events, last_modified=None, events_url=False, max_jobs_per_line=11):
@@ -161,21 +161,21 @@ def events_info(events, last_modified=None, events_url=False):
 
         repo_url = reverse("ci:view_repo", args=[ev.base.branch.repository.pk])
         event_url = reverse("ci:view_event", args=[ev.pk])
-        repo_link = format_html(u'<a href="{}">{}</a>', repo_url, ev.base.branch.repository.name)
+        repo_link = format_html('<a href="{}">{}</a>', repo_url, ev.base.branch.repository.name)
         pr_url = ''
         pr_desc = ''
         if ev.pull_request:
             pr_url = reverse("ci:view_pr", args=[ev.pull_request.pk])
             pr_desc = clean_str_for_format(str(ev.pull_request))
-            icon_link = format_html(u'<a href="{}"><i class="{}"></i></a>', ev.pull_request.url, ev.base.server().icon_class())
+            icon_link = format_html('<a href="{}"><i class="{}"></i></a>', ev.pull_request.url, ev.base.server().icon_class())
             if events_url:
-                event_desc = format_html(u'{} {} <a href="{}">{}</a>', icon_link, repo_link, event_url, pr_desc)
+                event_desc = format_html('{} {} <a href="{}">{}</a>', icon_link, repo_link, event_url, pr_desc)
             else:
-                event_desc = format_html(u'{} {} <a href="{}">{}</a>', icon_link, repo_link, pr_url, pr_desc)
+                event_desc = format_html('{} {} <a href="{}">{}</a>', icon_link, repo_link, pr_url, pr_desc)
         else:
-            event_desc = format_html(u'{} <a href="{}">{}', repo_link, event_url, ev.base.branch.name)
+            event_desc = format_html('{} <a href="{}">{}', repo_link, event_url, ev.base.branch.name)
             if ev.description:
-                event_desc = format_html(u'{} : {}', mark_safe(event_desc), clean_str_for_format(ev.description))
+                event_desc = format_html('{} : {}', mark_safe(event_desc), clean_str_for_format(ev.description))
             event_desc += '</a>'
 
         info = { 'id': ev.pk,
@@ -215,9 +215,9 @@ def events_info(events, last_modified=None, events_url=False):
                 jinfo = { 'id': job.pk,
                     'status': job.status_slug(),
                     }
-                job_desc = format_html(u'<a href="{}">{}</a>', jurl, format_html(job.unique_name()))
+                job_desc = format_html('<a href="{}">{}</a>', jurl, format_html(job.unique_name()))
                 if job_seconds:
-                    job_desc += format_html(u'<br />{}', job_seconds)
+                    job_desc += format_html('<br />{}', job_seconds)
                 if job.failed_step:
                     job_desc += format_html('<br />{}', job.failed_step)
                 if job.invalidated:

--- a/ci/EventsStatus.py
+++ b/ci/EventsStatus.py
@@ -166,7 +166,7 @@ def events_info(events, last_modified=None, events_url=False):
         pr_desc = ''
         if ev.pull_request:
             pr_url = reverse("ci:view_pr", args=[ev.pull_request.pk])
-            pr_desc = clean_str_for_format(repr(ev.pull_request))
+            pr_desc = clean_str_for_format(str(ev.pull_request))
             icon_link = format_html('<a href="{}"><i class="{}"></i></a>', ev.pull_request.url, ev.base.server().icon_class())
             if events_url:
                 event_desc = format_html('{} {} <a href="{}">{}</a>', icon_link, repo_link, event_url, pr_desc)

--- a/ci/GitCommitData.py
+++ b/ci/GitCommitData.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import models
+from . import models
 import logging
 logger = logging.getLogger('ci')
 

--- a/ci/GitCommitData.py
+++ b/ci/GitCommitData.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from . import models
 import logging
 logger = logging.getLogger('ci')

--- a/ci/ManualEvent.py
+++ b/ci/ManualEvent.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from . import models
 from . import GitCommitData
 import logging

--- a/ci/ManualEvent.py
+++ b/ci/ManualEvent.py
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import models
-import GitCommitData
+from . import models
+from . import GitCommitData
 import logging
 logger = logging.getLogger('ci')
 

--- a/ci/Permissions.py
+++ b/ci/Permissions.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from . import TimeUtils
 import logging
 from ci import models

--- a/ci/Permissions.py
+++ b/ci/Permissions.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import TimeUtils
+from . import TimeUtils
 import logging
 from ci import models
 from django.conf import settings

--- a/ci/PullRequestEvent.py
+++ b/ci/PullRequestEvent.py
@@ -13,11 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import models
+from . import models
 from django.urls import reverse
 import traceback
-import Permissions
-import event
+from . import Permissions
+from . import event
 import logging
 logger = logging.getLogger('ci')
 

--- a/ci/PullRequestEvent.py
+++ b/ci/PullRequestEvent.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from . import models
 from django.urls import reverse
 import traceback

--- a/ci/PushEvent.py
+++ b/ci/PushEvent.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import models
+from . import models
 import logging
 from ci import views
 from django.urls import reverse

--- a/ci/PushEvent.py
+++ b/ci/PushEvent.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from . import models
 import logging
 from ci import views

--- a/ci/ReleaseEvent.py
+++ b/ci/ReleaseEvent.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import models
+from . import models
 import logging
 logger = logging.getLogger('ci')
 

--- a/ci/ReleaseEvent.py
+++ b/ci/ReleaseEvent.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from . import models
 import logging
 logger = logging.getLogger('ci')

--- a/ci/RepositoryStatus.py
+++ b/ci/RepositoryStatus.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci import models
 from django.db.models import Prefetch
 from django.urls import reverse

--- a/ci/Stats.py
+++ b/ci/Stats.py
@@ -149,7 +149,7 @@ def num_prs_by_repo(request):
     bins = get_bins(start, datetime.timedelta(days=1))
     set_all_repo_prs(repos_q, start, "day", "Number of new PRs in last week, by day", context, "%m/%d", bins)
 
-    sorted_repos_by_name = sorted(repo_map.keys(), key=lambda v: repo_map[v].lower())
+    sorted_repos_by_name = sorted(list(repo_map.keys()), key=lambda v: repo_map[v].lower())
     repo_data = []
     for key in sorted_repos_by_name:
         repo_graphs = context.get("repo_graphs", {}).get(key, [])

--- a/ci/Stats.py
+++ b/ci/Stats.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.shortcuts import render
 from ci import models, TimeUtils
 from graphos.sources.simple import SimpleDataSource

--- a/ci/TimeUtils.py
+++ b/ci/TimeUtils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.utils import timezone
 import datetime, math

--- a/ci/admin.py
+++ b/ci/admin.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.contrib import admin
 from . import models
 

--- a/ci/ajax/tests/test_views.py
+++ b/ci/ajax/tests/test_views.py
@@ -72,14 +72,14 @@ class Tests(DBTester.DBTester):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
 
-        pr = utils.create_pr(title=u"Foo <type> & bar …")
+        pr = utils.create_pr(title="Foo <type> & bar …")
         url = reverse('ci:ajax:pr_update', args=[pr.pk])
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertIn('events', response.content)
         json_data = json.loads(response.content)
-        self.assertIn('events', json_data.keys())
+        self.assertIn('events', list(json_data.keys()))
 
     def test_event_update(self):
         ev = utils.create_event()
@@ -94,7 +94,7 @@ class Tests(DBTester.DBTester):
         self.assertEqual(response.status_code, 200)
         self.assertIn('events', response.content)
         json_data = json.loads(response.content)
-        self.assertIn('events', json_data.keys())
+        self.assertIn('events', list(json_data.keys()))
 
     def test_main_update(self):
         url = reverse('ci:ajax:main_update')
@@ -102,7 +102,7 @@ class Tests(DBTester.DBTester):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 400)
 
-        pr_open = utils.create_pr(title=u'Foo <type> & bar …', number=1)
+        pr_open = utils.create_pr(title='Foo <type> & bar …', number=1)
         ev_open = utils.create_event()
         pr_open.closed = False
         pr_open.save()
@@ -128,8 +128,8 @@ class Tests(DBTester.DBTester):
         response = self.client.get(url, data)
         self.assertEqual(response.status_code, 200)
         json_data = json.loads(response.content)
-        self.assertIn('repo_status', json_data.keys())
-        self.assertIn('closed', json_data.keys())
+        self.assertIn('repo_status', list(json_data.keys()))
+        self.assertIn('closed', list(json_data.keys()))
         self.assertEqual(len(json_data['repo_status']), 1)
         self.assertEqual(len(json_data['repo_status'][0]['prs']), 1)
         self.assertIn(escape(pr_open.title), json_data['repo_status'][0]['prs'][0]['description'])
@@ -186,8 +186,8 @@ class Tests(DBTester.DBTester):
         response = self.client.get(url, data)
         self.assertEqual(response.status_code, 200)
         json_data = json.loads(response.content)
-        self.assertIn('job_info', json_data.keys())
-        self.assertIn('results', json_data.keys())
+        self.assertIn('job_info', list(json_data.keys()))
+        self.assertIn('results', list(json_data.keys()))
         self.assertEqual(step_result.job.pk, json_data['job_info']['id'])
         self.assertEqual(step_result.pk, json_data['results'][0]['id'])
         self.assertEqual(json_data['job_info']['client_name'], client.name)
@@ -197,8 +197,8 @@ class Tests(DBTester.DBTester):
         response = self.client.get(url, data)
         self.assertEqual(response.status_code, 200)
         json_data = json.loads(response.content)
-        self.assertIn('job_info', json_data.keys())
-        self.assertIn('results', json_data.keys())
+        self.assertIn('job_info', list(json_data.keys()))
+        self.assertIn('results', list(json_data.keys()))
         # job_info is always returned
         self.assertNotEqual('', json_data['job_info'])
         self.assertEqual([], json_data['results'])
@@ -210,7 +210,7 @@ class Tests(DBTester.DBTester):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 400)
 
-        pr_open = utils.create_pr(title=u'Foo <type> & bar …', number=1)
+        pr_open = utils.create_pr(title='Foo <type> & bar …', number=1)
         ev_open = utils.create_event()
         pr_open.closed = False
         pr_open.save()
@@ -241,8 +241,8 @@ class Tests(DBTester.DBTester):
         response = self.client.get(url, data)
         self.assertEqual(response.status_code, 200)
         json_data = json.loads(response.content)
-        self.assertIn('repo_status', json_data.keys())
-        self.assertIn('closed', json_data.keys())
+        self.assertIn('repo_status', list(json_data.keys()))
+        self.assertIn('closed', list(json_data.keys()))
         self.assertEqual(len(json_data['repo_status']), 1)
         self.assertEqual(len(json_data['repo_status'][0]['prs']), 1)
         self.assertIn(escape(pr_open.title), json_data['repo_status'][0]['prs'][0]['description'])
@@ -261,7 +261,7 @@ class Tests(DBTester.DBTester):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         json_data = json.loads(response.content)
-        self.assertIn('clients', json_data.keys())
+        self.assertIn('clients', list(json_data.keys()))
 
     def test_repo_branches_status(self):
         # bad repo

--- a/ci/ajax/tests/test_views.py
+++ b/ci/ajax/tests/test_views.py
@@ -14,13 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.urls import reverse
 from django.utils.html import escape
 from ci.tests import utils
 from mock import patch
 from ci.github import api
 from ci import models, Permissions
-import json
 from ci.tests import DBTester
 from django.test import override_settings
 
@@ -45,7 +45,8 @@ class Tests(DBTester.DBTester):
         # should be ok since recipe isn't private
         response = self.client.get(url, data)
         self.assertEqual(response.status_code, 200)
-        self.assertIn(result.output, response.content)
+        json_data = response.json()
+        self.assertIn(result.output, json_data["contents"])
 
         result.job.recipe.private = True
         result.job.recipe.save()
@@ -64,7 +65,8 @@ class Tests(DBTester.DBTester):
         # recipe is private, but a collaborator
         response = self.client.get(url, data)
         self.assertEqual(response.status_code, 200)
-        self.assertIn(result.output, response.content)
+        json_data = response.json()
+        self.assertIn(result.output, json_data["contents"])
 
     def test_pr_update(self):
         url = reverse('ci:ajax:pr_update', args=[1000])
@@ -77,8 +79,7 @@ class Tests(DBTester.DBTester):
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertIn('events', response.content)
-        json_data = json.loads(response.content)
+        json_data = response.json()
         self.assertIn('events', list(json_data.keys()))
 
     def test_event_update(self):
@@ -92,8 +93,7 @@ class Tests(DBTester.DBTester):
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertIn('events', response.content)
-        json_data = json.loads(response.content)
+        json_data = response.json()
         self.assertIn('events', list(json_data.keys()))
 
     def test_main_update(self):
@@ -127,7 +127,7 @@ class Tests(DBTester.DBTester):
         data = {'last_request': 10, 'limit': 30}
         response = self.client.get(url, data)
         self.assertEqual(response.status_code, 200)
-        json_data = json.loads(response.content)
+        json_data = response.json()
         self.assertIn('repo_status', list(json_data.keys()))
         self.assertIn('closed', list(json_data.keys()))
         self.assertEqual(len(json_data['repo_status']), 1)
@@ -168,7 +168,7 @@ class Tests(DBTester.DBTester):
         # recipe no longer private, should work
         response = self.client.get(url, data)
         self.assertEqual(response.status_code, 200)
-        json_data = json.loads(response.content)
+        json_data = response.json()
         self.assertEqual(json_data['job_info']['client_name'], '')
         self.assertEqual(json_data['job_info']['client_url'], '')
 
@@ -185,7 +185,7 @@ class Tests(DBTester.DBTester):
         # should work now
         response = self.client.get(url, data)
         self.assertEqual(response.status_code, 200)
-        json_data = json.loads(response.content)
+        json_data = response.json()
         self.assertIn('job_info', list(json_data.keys()))
         self.assertIn('results', list(json_data.keys()))
         self.assertEqual(step_result.job.pk, json_data['job_info']['id'])
@@ -196,7 +196,7 @@ class Tests(DBTester.DBTester):
         data['last_request'] = json_data['last_request']+10
         response = self.client.get(url, data)
         self.assertEqual(response.status_code, 200)
-        json_data = json.loads(response.content)
+        json_data = response.json()
         self.assertIn('job_info', list(json_data.keys()))
         self.assertIn('results', list(json_data.keys()))
         # job_info is always returned
@@ -240,7 +240,7 @@ class Tests(DBTester.DBTester):
         data["repo_id"] = pr_open.repository.pk
         response = self.client.get(url, data)
         self.assertEqual(response.status_code, 200)
-        json_data = json.loads(response.content)
+        json_data = response.json()
         self.assertIn('repo_status', list(json_data.keys()))
         self.assertIn('closed', list(json_data.keys()))
         self.assertEqual(len(json_data['repo_status']), 1)
@@ -260,7 +260,7 @@ class Tests(DBTester.DBTester):
         mock_allowed.return_value = True
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        json_data = json.loads(response.content)
+        json_data = response.json()
         self.assertIn('clients', list(json_data.keys()))
 
     def test_repo_branches_status(self):
@@ -274,7 +274,7 @@ class Tests(DBTester.DBTester):
         url = reverse('ci:ajax:repo_branches_status', args=[branch.repository.user.name, branch.repository.name])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        json_data = json.loads(response.content)
+        json_data = response.json()
         self.assertEqual(len(json_data["branches"]), 0)
 
         # should be OK
@@ -282,7 +282,7 @@ class Tests(DBTester.DBTester):
         branch.save()
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        json_data = json.loads(response.content)
+        json_data = response.json()
         self.assertEqual(len(json_data["branches"]), 1)
         self.assertEqual(json_data["branches"][0]["name"], branch.name)
         self.assertEqual(json_data["branches"][0]["status"], branch.status_slug())
@@ -301,7 +301,7 @@ class Tests(DBTester.DBTester):
         url = reverse('ci:ajax:repo_prs_status', args=[pr.repository.user.name, pr.repository.name])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        json_data = json.loads(response.content)
+        json_data = response.json()
         self.assertEqual(len(json_data["prs"]), 0)
 
         # should be OK
@@ -309,7 +309,7 @@ class Tests(DBTester.DBTester):
         pr.save()
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        json_data = json.loads(response.content)
+        json_data = response.json()
         self.assertEqual(len(json_data["prs"]), 1)
         self.assertEqual(json_data["prs"][0]["number"], pr.number)
         self.assertEqual(json_data["prs"][0]["status"], pr.status_slug())
@@ -327,7 +327,7 @@ class Tests(DBTester.DBTester):
         get_data = {'last_request': 10}
         response = self.client.get(url, get_data)
         self.assertEqual(response.status_code, 200)
-        data = json.loads(response.content)
+        data = response.json()
         self.assertEqual(len(data["repos"]), 0)
         self.assertEqual(len(data["prs"]), 0)
         self.assertEqual(len(data["events"]), 0)
@@ -346,7 +346,7 @@ class Tests(DBTester.DBTester):
         # not open
         response = self.client.get(url, get_data)
         self.assertEqual(response.status_code, 200)
-        data = json.loads(response.content)
+        data = response.json()
         self.assertEqual(len(data["repos"]), 0)
         self.assertEqual(len(data["prs"]), 0)
         self.assertEqual(len(data["events"]), 0)
@@ -358,7 +358,7 @@ class Tests(DBTester.DBTester):
         pr.save()
         response = self.client.get(url, get_data)
         self.assertEqual(response.status_code, 200)
-        data = json.loads(response.content)
+        data = response.json()
         self.assertEqual(len(data["repos"]), 1)
         self.assertEqual(len(data["prs"]), 1)
         self.assertEqual(len(data["events"]), 1)
@@ -369,7 +369,7 @@ class Tests(DBTester.DBTester):
         get_data["last_request"] = data["last_request"] + 10
         response = self.client.get(url, get_data)
         self.assertEqual(response.status_code, 200)
-        data = json.loads(response.content)
+        data = response.json()
         self.assertEqual(len(data["repos"]), 1)
         self.assertEqual(len(data["prs"]), 1)
         self.assertEqual(len(data["events"]), 1)

--- a/ci/ajax/urls.py
+++ b/ci/ajax/urls.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.conf.urls import url
 from . import views
 

--- a/ci/ajax/views.py
+++ b/ci/ajax/views.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.utils import timezone
 from django.http import JsonResponse, HttpResponseBadRequest, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, render

--- a/ci/bitbucket/api.py
+++ b/ci/bitbucket/api.py
@@ -118,7 +118,7 @@ class BitBucketAPI(GitAPI):
         data = self.get_all_pages(url)
         branches = []
         if not self._bad_response and data:
-            branches = data.keys()
+            branches = list(data.keys())
             branches.sort()
         return branches
 

--- a/ci/bitbucket/api.py
+++ b/ci/bitbucket/api.py
@@ -35,7 +35,7 @@ class BitBucketAPI(GitAPI):
         self._api2_url = config.get("api2_url", "")
         self._api1_url = config.get("api1_url", "")
         self._bitbucket_url = config.get("html_url", "")
-        self._prefix = "%s_" % config["hostname"]
+        self._prefix = "%s_" % config.get("hostname", "unknown_bitbucket")
         self._repos_key = "%s_repos" % self._prefix
         self._org_repos_key = "%s_org_repos" % self._prefix
         self._user_key = "%s_user" % self._prefix

--- a/ci/bitbucket/api.py
+++ b/ci/bitbucket/api.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.urls import reverse
 import logging
 import requests

--- a/ci/bitbucket/oauth.py
+++ b/ci/bitbucket/oauth.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci.oauth_api import OAuth
 from django.conf import settings
 from django.urls import reverse

--- a/ci/bitbucket/tests/test_api.py
+++ b/ci/bitbucket/tests/test_api.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import TestCase, Client
 from django.urls import reverse
 from django.test.client import RequestFactory
@@ -23,7 +24,10 @@ from ci.git_api import GitException
 from mock import patch
 import requests
 import os
-import urllib.parse
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
 
 @override_settings(INSTALLED_GITSERVERS=[utils.bitbucket_config()])
 class Tests(TestCase):
@@ -155,7 +159,7 @@ class Tests(TestCase):
         event0 = {'events': ['pullrequest:created', 'repo:push'], 'url': 'no_url'}
         event1 = {'events': ['pullrequest:created', 'repo:other_action'], 'url': 'no_url'}
         get_data = {'values': [event0, event1]}
-        callback_url = urllib.parse.urljoin(self.gapi._civet_url, reverse('ci:bitbucket:webhook', args=[self.user.build_key]))
+        callback_url = urljoin(self.gapi._civet_url, reverse('ci:bitbucket:webhook', args=[self.user.build_key]))
 
         with self.settings(INSTALLED_GITSERVERS=[utils.bitbucket_config(install_webhook=True)]):
             api = self.server.api()

--- a/ci/bitbucket/tests/test_api.py
+++ b/ci/bitbucket/tests/test_api.py
@@ -23,7 +23,7 @@ from ci.git_api import GitException
 from mock import patch
 import requests
 import os
-import urlparse
+import urllib.parse
 
 @override_settings(INSTALLED_GITSERVERS=[utils.bitbucket_config()])
 class Tests(TestCase):
@@ -155,7 +155,7 @@ class Tests(TestCase):
         event0 = {'events': ['pullrequest:created', 'repo:push'], 'url': 'no_url'}
         event1 = {'events': ['pullrequest:created', 'repo:other_action'], 'url': 'no_url'}
         get_data = {'values': [event0, event1]}
-        callback_url = urlparse.urljoin(self.gapi._civet_url, reverse('ci:bitbucket:webhook', args=[self.user.build_key]))
+        callback_url = urllib.parse.urljoin(self.gapi._civet_url, reverse('ci:bitbucket:webhook', args=[self.user.build_key]))
 
         with self.settings(INSTALLED_GITSERVERS=[utils.bitbucket_config(install_webhook=True)]):
             api = self.server.api()
@@ -231,11 +231,11 @@ class Tests(TestCase):
         pr0_ret = {"title": "some title", "number": 123, "html_url": "some url"}
         mock_get.return_value = utils.Response({"values":[pr0]})
         prs = api.get_open_prs(repo.user.name, repo.name)
-        self.assertEquals([pr0_ret], prs)
+        self.assertEqual([pr0_ret], prs)
 
         mock_get.side_effect = Exception("BAM!")
         prs = api.get_open_prs(repo.user.name, repo.name)
-        self.assertEquals(prs, None)
+        self.assertEqual(prs, None)
 
     def test_unimplemented(self):
         """

--- a/ci/bitbucket/tests/test_oauth.py
+++ b/ci/bitbucket/tests/test_oauth.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import TestCase, RequestFactory, Client
 from django.urls import reverse
 from django.conf import settings

--- a/ci/bitbucket/tests/test_views.py
+++ b/ci/bitbucket/tests/test_views.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.urls import reverse
 from django.test import override_settings
 from django.conf import settings
@@ -43,12 +44,12 @@ class Tests(DBTester.DBTester):
         # only post allowed
         response = self.client.get(url)
         self.assertEqual(response.status_code, 405) # not allowed
-        self.assertNotEqual(response.content, "OK")
+        self.assertNotEqual(response.content, b"OK")
 
         # no user
         response = self.client.post(url)
         self.assertEqual(response.status_code, 400)
-        self.assertNotEqual(response.content, "OK")
+        self.assertNotEqual(response.content, b"OK")
 
         # no json
         user = utils.get_test_user(server=self.server)
@@ -56,14 +57,14 @@ class Tests(DBTester.DBTester):
         data = {'key': 'value'}
         response = self.client.post(url, data)
         self.assertEqual(response.status_code, 400)
-        self.assertNotEqual(response.content, "OK")
+        self.assertNotEqual(response.content, b"OK")
 
         # bad json
         user = utils.get_test_user(self.server)
         url = reverse('ci:bitbucket:webhook', args=[user.build_key])
         response = self.client_post_json(url, data)
         self.assertEqual(response.status_code, 400)
-        self.assertNotEqual(response.content, "OK")
+        self.assertNotEqual(response.content, b"OK")
 
     def test_pull_request(self):
         url = reverse('ci:bitbucket:webhook', args=[self.build_user.build_key])
@@ -76,21 +77,21 @@ class Tests(DBTester.DBTester):
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
         self.compare_counts(jobs=2, ready=1, events=1, commits=2, users=1, repos=1, branches=1, prs=1, active=2, active_repos=1, num_git_events=1)
 
         py_data['pullrequest']['state'] = 'DECLINED'
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
         self.compare_counts(pr_closed=True, num_git_events=1)
 
         py_data['pullrequest']['state'] = 'BadState'
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 400)
-        self.assertNotEqual(response.content, "OK")
+        self.assertNotEqual(response.content, b"OK")
         self.compare_counts(pr_closed=True, num_git_events=1)
 
     def test_push(self):
@@ -106,7 +107,7 @@ class Tests(DBTester.DBTester):
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
         self.compare_counts(jobs=2, ready=1, events=1, commits=2, active=2, active_repos=1, num_git_events=1)
         ev = models.Event.objects.latest()
         self.assertEqual(ev.cause, models.Event.PUSH)
@@ -116,7 +117,7 @@ class Tests(DBTester.DBTester):
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
         self.compare_counts(num_git_events=1)
 
         # Sometimes the new data isn't there
@@ -124,7 +125,7 @@ class Tests(DBTester.DBTester):
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 400)
-        self.assertNotEqual(response.content, "OK")
+        self.assertNotEqual(response.content, b"OK")
         self.compare_counts(num_git_events=1)
 
         # Sometimes the old data isn't there
@@ -132,5 +133,5 @@ class Tests(DBTester.DBTester):
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 400)
-        self.assertNotEqual(response.content, "OK")
+        self.assertNotEqual(response.content, b"OK")
         self.compare_counts(num_git_events=1)

--- a/ci/bitbucket/urls.py
+++ b/ci/bitbucket/urls.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.conf.urls import url
 from ci.bitbucket import oauth, views
 

--- a/ci/bitbucket/views.py
+++ b/ci/bitbucket/views.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.views.decorators.csrf import csrf_exempt
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseNotAllowed
 import logging, traceback

--- a/ci/client/ParseOutput.py
+++ b/ci/client/ParseOutput.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci import models
 import re
 
@@ -29,9 +30,9 @@ def set_job_modules(job, output):
         2) module2
         ...
     """
-    lines_match = re.search("(?<=^Currently Loaded Modulefiles:$)(\s+\d+\) (.*))+", output, flags=re.MULTILINE)
+    lines_match = re.search(r"(?<=^Currently Loaded Modulefiles:$)(\s+\d+\) (.*))+", output, flags=re.MULTILINE)
     if not lines_match:
-        lines_match = re.search("(?<=^Currently Loaded Modules:$)(\s+\d+\) (.*))+", output, flags=re.MULTILINE)
+        lines_match = re.search(r"(?<=^Currently Loaded Modules:$)(\s+\d+\) (.*))+", output, flags=re.MULTILINE)
         if not lines_match:
             mod_obj, created = models.LoadedModule.objects.get_or_create(name="None")
             job.loaded_modules.add(mod_obj)
@@ -78,13 +79,13 @@ def set_job_os(job, output):
     If no match was found then set the job OS to "Other"
     """
     # This matches against the output of "lsb_release -a".
-    if output_os_search(job, output, "^Distributor ID:\s+(.+)$", "^Release:\s+(.+)$", "^Codename:\s+(.+)$"):
+    if output_os_search(job, output, r"^Distributor ID:\s+(.+)$", r"^Release:\s+(.+)$", r"^Codename:\s+(.+)$"):
         return
     # This matches against the output of "systeminfo |grep '^OS'"
-    if output_os_search(job, output, "^OS Name:\s+(.+)$", "^OS Version:\s+(.+)$", "^OS Configuration:\s+(.+)$"):
+    if output_os_search(job, output, r"^OS Name:\s+(.+)$", r"^OS Version:\s+(.+)$", r"^OS Configuration:\s+(.+)$"):
         return
     # This matches against the output of "sw_vers".
-    if output_os_search(job, output, "^ProductName:\s+(.+)$", "^ProductVersion:\s+(.+)$", "^BuildVersion:\s+(.+)$"):
+    if output_os_search(job, output, r"^ProductName:\s+(.+)$", r"^ProductVersion:\s+(.+)$", r"^BuildVersion:\s+(.+)$"):
         return
 
     # No OS found
@@ -99,7 +100,7 @@ def set_job_stats(job):
     skipped = 0
     for s in job.step_results.all():
         output = "\n".join(s.clean_output().split("<br/>"))
-        matches = re.findall('>(?P<passed>\d+) passed<.*, .*>(?P<skipped>\d+) skipped<.*, .*>(?P<failed>\d+) failed',
+        matches = re.findall(r'>(?P<passed>\d+) passed<.*, .*>(?P<skipped>\d+) skipped<.*, .*>(?P<failed>\d+) failed',
                 output, flags=re.IGNORECASE)
         for match in matches:
             passed += int(match[0])

--- a/ci/client/ProcessCommands.py
+++ b/ci/client/ProcessCommands.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci import models
 import re
 

--- a/ci/client/UpdateRemoteStatus.py
+++ b/ci/client/UpdateRemoteStatus.py
@@ -14,8 +14,8 @@
 
 from ci import models
 from django.urls import reverse
-import ProcessCommands
-import ParseOutput
+from . import ProcessCommands
+from . import ParseOutput
 import logging
 logger = logging.getLogger('ci')
 

--- a/ci/client/UpdateRemoteStatus.py
+++ b/ci/client/UpdateRemoteStatus.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci import models
 from django.urls import reverse
 from . import ProcessCommands

--- a/ci/client/tests/ClientTester.py
+++ b/ci/client/tests/ClientTester.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import os
 from ci.tests import utils, DBTester
 from ci.client import ParseOutput

--- a/ci/client/tests/test_ParseOutput.py
+++ b/ci/client/tests/test_ParseOutput.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ClientTester
+from . import ClientTester
 from ci.client import ParseOutput
 from ci.tests import utils
 from ci import models

--- a/ci/client/tests/test_ParseOutput.py
+++ b/ci/client/tests/test_ParseOutput.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from . import ClientTester
 from ci.client import ParseOutput
 from ci.tests import utils

--- a/ci/client/tests/test_ProcessCommands.py
+++ b/ci/client/tests/test_ProcessCommands.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from . import ClientTester
 from django.test import override_settings
 from ci.client import ProcessCommands

--- a/ci/client/tests/test_ProcessCommands.py
+++ b/ci/client/tests/test_ProcessCommands.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ClientTester
+from . import ClientTester
 from django.test import override_settings
 from ci.client import ProcessCommands
 from ci.tests import utils

--- a/ci/client/tests/test_UpdateRemoteStatus.py
+++ b/ci/client/tests/test_UpdateRemoteStatus.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import override_settings
 from . import ClientTester
 from ci import models

--- a/ci/client/tests/test_UpdateRemoteStatus.py
+++ b/ci/client/tests/test_UpdateRemoteStatus.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from django.test import override_settings
-import ClientTester
+from . import ClientTester
 from ci import models
 from ci.tests import utils
 from ci.client import UpdateRemoteStatus

--- a/ci/client/tests/test_views.py
+++ b/ci/client/tests/test_views.py
@@ -23,7 +23,7 @@ from ci.client import views
 from ci.recipe import file_utils
 from ci.tests import utils
 from ci.github.api import GitHubAPI
-import ClientTester
+from . import ClientTester
 
 @override_settings(INSTALLED_GITSERVERS=[utils.github_config()])
 class Tests(ClientTester.ClientTester):

--- a/ci/client/tests/test_views.py
+++ b/ci/client/tests/test_views.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.urls import reverse
 from django.http import HttpResponseNotAllowed, HttpResponseBadRequest
 from django.test import override_settings
@@ -107,7 +108,7 @@ class Tests(ClientTester.ClientTester):
         response = self.client.get(url)
         self.compare_counts(num_clients=1)
         self.assertEqual(response.status_code, 200)
-        data = json.loads(response.content)
+        data = response.json()
         self.assertIn('jobs', data)
         self.assertEqual(len(data['jobs']), 0)
 
@@ -146,7 +147,7 @@ class Tests(ClientTester.ClientTester):
         response = self.client.get(url)
         self.compare_counts()
         self.assertEqual(response.status_code, 200)
-        data = json.loads(response.content)
+        data = response.json()
         self.assertIn('jobs', data)
         self.assertEqual(len(data['jobs']), 4)
         self.assertEqual(data['jobs'][0]['id'], job2.pk)
@@ -276,7 +277,7 @@ class Tests(ClientTester.ClientTester):
         self.compare_counts(num_clients=1)
         self.assertEqual(response.status_code, 200)
 
-        data = json.loads(response.content)
+        data = response.json()
         self.assertEqual(data['job_id'], job_id)
         self.assertEqual(data['status'], 'OK')
         job.refresh_from_db()
@@ -312,7 +313,7 @@ class Tests(ClientTester.ClientTester):
         self.compare_counts()
         self.assertEqual(response.status_code, 200)
 
-        data = json.loads(response.content)
+        data = response.json()
         self.assertEqual(data['job_id'], job_id)
         self.assertEqual(data['status'], 'OK')
         job.refresh_from_db()
@@ -342,7 +343,7 @@ class Tests(ClientTester.ClientTester):
         response = self.client_post_json(url, post_data)
         self.compare_counts()
         self.assertEqual(response.status_code, 200)
-        data = json.loads(response.content)
+        data = response.json()
         self.assertEqual(data['job_id'], job_id)
         self.assertEqual(data['status'], 'OK')
 
@@ -354,7 +355,7 @@ class Tests(ClientTester.ClientTester):
         response = self.client_post_json(url, post_data)
         self.compare_counts(num_clients=1)
         self.assertEqual(response.status_code, 200)
-        data = json.loads(response.content)
+        data = response.json()
         self.assertEqual(data['job_id'], job_id)
         self.assertEqual(data['status'], 'OK')
         job.refresh_from_db()
@@ -495,7 +496,7 @@ class Tests(ClientTester.ClientTester):
         response = self.client_post_json(url, post_data)
         self.compare_counts(num_events_completed=1, num_jobs_completed=1)
         self.assertEqual(response.status_code, 200)
-        data = json.loads(response.content)
+        data = response.json()
         self.assertIn('message', data)
         self.assertEqual(data['status'], 'OK')
         job.refresh_from_db()
@@ -517,7 +518,7 @@ class Tests(ClientTester.ClientTester):
         response = self.client_post_json(url, post_data)
         self.compare_counts(ready=1)
         self.assertEqual(response.status_code, 200)
-        data = json.loads(response.content)
+        data = response.json()
         self.assertIn('message', data)
         self.assertEqual(data['status'], 'OK')
         job2 = models.Job.objects.get(pk=job2.pk)
@@ -613,7 +614,7 @@ class Tests(ClientTester.ClientTester):
         self.assertEqual(response.status_code, 200)
         result.refresh_from_db()
         self.assertEqual(result.status, models.JobStatus.RUNNING)
-        data = json.loads(response.content)
+        data = response.json()
         self.assertEqual(data["command"], None)
         self.assertEqual(data["status"], "OK")
 
@@ -626,7 +627,7 @@ class Tests(ClientTester.ClientTester):
         self.assertEqual(response.status_code, 200)
         result.refresh_from_db()
         self.assertEqual(result.status, models.JobStatus.CANCELED)
-        data = json.loads(response.content)
+        data = response.json()
         self.assertEqual(data["command"], "cancel")
         self.assertEqual(data["status"], "OK")
 
@@ -682,7 +683,7 @@ class Tests(ClientTester.ClientTester):
         response = self.client_post_json(url, post_data)
         self.compare_counts()
         self.assertEqual(response.status_code, 200)
-        data = json.loads(response.content)
+        data = response.json()
         self.assertEqual(data["status"], "OK")
         self.assertEqual(data["command"], None)
         result.refresh_from_db()
@@ -696,7 +697,7 @@ class Tests(ClientTester.ClientTester):
         self.compare_counts()
         self.assertEqual(response.status_code, 200)
         result.refresh_from_db()
-        data = json.loads(response.content)
+        data = response.json()
         self.assertEqual(result.status, models.JobStatus.NOT_STARTED)
         self.assertEqual(data["status"], "OK")
         self.assertEqual(data["command"], "cancel")
@@ -709,7 +710,7 @@ class Tests(ClientTester.ClientTester):
         self.compare_counts()
         self.assertEqual(response.status_code, 200)
         result.refresh_from_db()
-        data = json.loads(response.content)
+        data = response.json()
         self.assertEqual(result.status, models.JobStatus.CANCELED)
         self.assertEqual(data["status"], "OK")
         self.assertEqual(data["command"], "cancel")
@@ -844,7 +845,7 @@ class Tests(ClientTester.ClientTester):
         result.job.refresh_from_db()
         self.assertEqual(result.status, models.JobStatus.FAILED)
         self.assertEqual(result.job.failed_step, result.name)
-        data = json.loads(response.content)
+        data = response.json()
         self.assertEqual(data["status"], "OK")
         self.assertEqual(data["command"], None)
 
@@ -861,7 +862,7 @@ class Tests(ClientTester.ClientTester):
         response = self.client_post_json(url, post_data)
         self.compare_counts()
         self.assertEqual(response.status_code, 200)
-        json_data = json.loads(response.content)
+        json_data = response.json()
         self.assertFalse(json_data.get('next_step'))
         result.refresh_from_db()
         result.job.refresh_from_db()
@@ -882,7 +883,7 @@ class Tests(ClientTester.ClientTester):
         response = self.client_post_json(url, post_data)
         self.compare_counts()
         self.assertEqual(response.status_code, 200)
-        json_data = json.loads(response.content)
+        json_data = response.json()
         self.assertFalse(json_data.get('next_step'))
         result.refresh_from_db()
         result.job.refresh_from_db()
@@ -906,7 +907,7 @@ class Tests(ClientTester.ClientTester):
         url = reverse('ci:client:update_remote_job_status', args=[j.pk])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertIn("not allowed", response.content)
+        self.assertContains(response, "not allowed")
 
         response = self.client.post(url)
         self.assertEqual(response.status_code, 405)
@@ -914,7 +915,7 @@ class Tests(ClientTester.ClientTester):
         mock_collab.return_value = True
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertNotIn("not allowed", response.content)
+        self.assertNotContains(response, "not allowed")
 
         response = self.client.post(url)
         self.assertEqual(response.status_code, 302)

--- a/ci/client/urls.py
+++ b/ci/client/urls.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.conf.urls import url
 from . import views
 

--- a/ci/client/views.py
+++ b/ci/client/views.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.views.decorators.csrf import csrf_exempt
 from django.db.models import Sum
 from django.http import JsonResponse, HttpResponseNotAllowed, HttpResponseBadRequest

--- a/ci/client/views.py
+++ b/ci/client/views.py
@@ -24,7 +24,7 @@ import logging
 from django.conf import settings
 from django.db import transaction
 from datetime import timedelta
-import UpdateRemoteStatus
+from . import UpdateRemoteStatus
 from django.shortcuts import render, redirect, get_object_or_404
 logger = logging.getLogger('ci')
 

--- a/ci/event.py
+++ b/ci/event.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import models
+from . import models
 import logging
 import re
 from django.urls import reverse
@@ -53,7 +53,7 @@ def get_active_labels(server, changed_files):
     config = server.server_config()
     patterns = config.get("recipe_label_activation", {})
     labels = {}
-    for label, regex in patterns.items():
+    for label, regex in list(patterns.items()):
         for f in changed_files:
             if re.match(regex, f):
                 count = labels.get(label, 0)

--- a/ci/event.py
+++ b/ci/event.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from . import models
 import logging
 import re
@@ -53,7 +54,7 @@ def get_active_labels(server, changed_files):
     config = server.server_config()
     patterns = config.get("recipe_label_activation", {})
     labels = {}
-    for label, regex in list(patterns.items()):
+    for label, regex in patterns.items():
         for f in changed_files:
             if re.match(regex, f):
                 count = labels.get(label, 0)

--- a/ci/forms.py
+++ b/ci/forms.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django import forms
 from ci import models
 

--- a/ci/git_api.py
+++ b/ci/git_api.py
@@ -38,8 +38,7 @@ def copydoc(fromfunc, sep="\n"):
         return func
     return _decorator
 
-class GitAPI(object):
-    __metaclass__ = abc.ABCMeta
+class GitAPI(object, metaclass=abc.ABCMeta):
     PENDING = 0
     ERROR = 1
     SUCCESS = 2

--- a/ci/git_api.py
+++ b/ci/git_api.py
@@ -13,17 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import abc
-
-class GitException(Exception):
-    pass
-
 import logging
 import json
 import requests
+from django.utils import six
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 logger = logging.getLogger('ci')
+
+class GitException(Exception):
+    pass
 
 def copydoc(fromfunc, sep="\n"):
     """
@@ -38,7 +39,8 @@ def copydoc(fromfunc, sep="\n"):
         return func
     return _decorator
 
-class GitAPI(object, metaclass=abc.ABCMeta):
+@six.add_metaclass(abc.ABCMeta)
+class GitAPI(object):
     PENDING = 0
     ERROR = 1
     SUCCESS = 2

--- a/ci/github/api.py
+++ b/ci/github/api.py
@@ -13,12 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.urls import reverse
 import logging
 from ci.git_api import GitAPI, GitException, copydoc
 import requests
 import re
-import urllib.parse
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
 
 logger = logging.getLogger('ci')
 
@@ -336,7 +340,7 @@ class GitHubAPI(GitAPI):
             return
 
         hook_url = '%s/repos/%s/%s/hooks' % (self._api_url, owner, repo)
-        callback_url = urllib.parse.urljoin(self._civet_url, reverse('ci:github:webhook', args=[user_build_key]))
+        callback_url = urljoin(self._civet_url, reverse('ci:github:webhook', args=[user_build_key]))
         data = self.get_all_pages(hook_url)
         if self._bad_response or data is None:
             err = 'Failed to access webhook to %s/%s for user %s' % (owner, repo, user)

--- a/ci/github/api.py
+++ b/ci/github/api.py
@@ -18,7 +18,7 @@ import logging
 from ci.git_api import GitAPI, GitException, copydoc
 import requests
 import re
-import urlparse
+import urllib.parse
 
 logger = logging.getLogger('ci')
 
@@ -336,7 +336,7 @@ class GitHubAPI(GitAPI):
             return
 
         hook_url = '%s/repos/%s/%s/hooks' % (self._api_url, owner, repo)
-        callback_url = urlparse.urljoin(self._civet_url, reverse('ci:github:webhook', args=[user_build_key]))
+        callback_url = urllib.parse.urljoin(self._civet_url, reverse('ci:github:webhook', args=[user_build_key]))
         data = self.get_all_pages(hook_url)
         if self._bad_response or data is None:
             err = 'Failed to access webhook to %s/%s for user %s' % (owner, repo, user)

--- a/ci/github/oauth.py
+++ b/ci/github/oauth.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci.oauth_api import OAuth
 from django.conf import settings
 from django.urls import reverse

--- a/ci/github/tests/test_api.py
+++ b/ci/github/tests/test_api.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.urls import reverse
 from django.test import override_settings
 import requests

--- a/ci/github/tests/test_api.py
+++ b/ci/github/tests/test_api.py
@@ -606,11 +606,11 @@ class Tests(DBTester.DBTester):
         pr0 = {"title": "some title", "number": 123, "html_url": "some url"}
         mock_get.return_value = utils.Response([pr0])
         prs = api.get_open_prs(repo.user.name, repo.name)
-        self.assertEquals([pr0], prs)
+        self.assertEqual([pr0], prs)
 
         mock_get.side_effect = Exception("BAM!")
         prs = api.get_open_prs(repo.user.name, repo.name)
-        self.assertEquals(prs, None)
+        self.assertEqual(prs, None)
 
     @patch.object(requests, 'post')
     def test_pr_review_comment(self, mock_post):

--- a/ci/github/tests/test_oauth.py
+++ b/ci/github/tests/test_oauth.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import TestCase, RequestFactory, Client
 from django.urls import reverse
 from django.test import override_settings

--- a/ci/github/tests/test_views.py
+++ b/ci/github/tests/test_views.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.urls import reverse
 from ci import models
 from ci.tests import utils
@@ -81,7 +82,7 @@ class Tests(DBTester.DBTester):
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
         self.compare_counts(num_git_events=1)
         self.assertEqual(mock_get.call_count, 0)
         self.assertEqual(mock_del.call_count, 0)
@@ -92,7 +93,7 @@ class Tests(DBTester.DBTester):
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
         self.compare_counts(num_git_events=1)
         self.assertEqual(mock_get.call_count, 0)
         self.assertEqual(mock_del.call_count, 0)
@@ -104,7 +105,7 @@ class Tests(DBTester.DBTester):
         mock_get.call_count = 0
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
         self.compare_counts(jobs=2,
                 ready=1,
                 events=1,
@@ -129,7 +130,7 @@ class Tests(DBTester.DBTester):
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
         self.compare_counts(pr_closed=True, num_git_events=1)
         self.assertEqual(mock_get.call_count, 1) # for changed files
         self.assertEqual(mock_del.call_count, 0)
@@ -141,7 +142,7 @@ class Tests(DBTester.DBTester):
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
         self.compare_counts(num_git_events=1)
         self.assertEqual(mock_get.call_count, 1) # for changed files
         self.assertEqual(mock_del.call_count, 0)
@@ -153,7 +154,7 @@ class Tests(DBTester.DBTester):
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
         self.compare_counts(num_git_events=1)
         self.assertEqual(mock_get.call_count, 0)
         self.assertEqual(mock_del.call_count, 0)
@@ -164,7 +165,7 @@ class Tests(DBTester.DBTester):
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 400)
-        self.assertIn("bad_action", response.content)
+        self.assertIn(b"bad_action", response.content)
         self.compare_counts(num_git_events=1)
         self.assertEqual(mock_get.call_count, 0)
         self.assertEqual(mock_del.call_count, 0)
@@ -181,7 +182,7 @@ class Tests(DBTester.DBTester):
             self.set_counts()
             response = self.client_post_json(url, py_data)
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.content, "OK")
+            self.assertEqual(response.content, b"OK")
             self.compare_counts(num_git_events=1)
             self.assertEqual(mock_get.call_count, 2) # 1 for changed files, 1 in remove_pr_todo_labels
             self.assertEqual(mock_del.call_count, 1) # for remove_pr_todo_labels
@@ -195,7 +196,7 @@ class Tests(DBTester.DBTester):
             self.set_counts()
             response = self.client_post_json(url, py_data)
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.content, "OK")
+            self.assertEqual(response.content, b"OK")
             self.compare_counts(jobs=2,
                     ready=1,
                     events=1,
@@ -227,7 +228,7 @@ class Tests(DBTester.DBTester):
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
         self.compare_counts(jobs=2, ready=1, events=1, commits=2, active=2, active_repos=1, num_git_events=1)
         ev = models.Event.objects.latest()
         self.assertEqual(ev.cause, models.Event.PUSH)
@@ -242,7 +243,7 @@ class Tests(DBTester.DBTester):
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
         self.compare_counts(jobs=2, ready=1, events=1, commits=2, active=2, num_git_events=1)
         ev = models.Event.objects.latest()
         self.assertEqual(ev.description, "Merge commit 123456")

--- a/ci/github/urls.py
+++ b/ci/github/urls.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.conf.urls import url
 from ci.github import oauth, views
 

--- a/ci/github/views.py
+++ b/ci/github/views.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.views.decorators.csrf import csrf_exempt
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseNotAllowed
 import logging, traceback

--- a/ci/gitlab/api.py
+++ b/ci/gitlab/api.py
@@ -42,8 +42,7 @@ class GitLabAPI(GitAPI):
         self._api_url = '%s/api/v4' % config.get("api_url", "")
         self._html_url = config.get("html_url", "")
         self._ssl_cert = config.get("ssl_cert", False)
-        self._hostname = config.get("hostname")[0]
-        self._prefix = "%s_" % config["hostname"]
+        self._prefix = "%s_" % config.get("hostname", "unknown_gitlab")
         self._repos_key = "%s_repos" % self._prefix
         self._org_repos_key = "%s_org_repos" % self._prefix
         self._user_key= "%s_user" % self._prefix

--- a/ci/gitlab/api.py
+++ b/ci/gitlab/api.py
@@ -13,13 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.urls import reverse
 import logging
-import urllib.request, urllib.parse, urllib.error, requests
+import requests
 from ci.git_api import GitAPI, GitException, copydoc
 import re
-import urllib.parse
 import json
+try:
+    from urllib.parse import quote_plus, urljoin
+except ImportError:
+    from urllib import quote_plus
+    from urlparse import urljoin
 
 logger = logging.getLogger('ci')
 
@@ -69,7 +74,7 @@ class GitLabAPI(GitAPI):
 
     def _gitlab_id(self, owner, repo):
         name = '%s/%s' % (owner, repo)
-        return urllib.parse.quote_plus(name)
+        return quote_plus(name)
 
     def _repo_url(self, owner, repo):
         return '%s/projects/%s' % (self._api_url, self._gitlab_id(owner, repo))
@@ -89,7 +94,7 @@ class GitLabAPI(GitAPI):
             repo_id[int]: ID of the repo
             branch_id[int]: ID of the branch
         """
-        return "%s/projects/%s/repository/branches/%s" % (self._api_url, repo_id, urllib.parse.quote_plus(str(branch_id)))
+        return "%s/projects/%s/repository/branches/%s" % (self._api_url, repo_id, quote_plus(str(branch_id)))
 
     @copydoc(GitAPI.branch_html_url)
     def branch_html_url(self, owner, repo, branch):
@@ -258,7 +263,7 @@ class GitLabAPI(GitAPI):
 
     @copydoc(GitAPI.last_sha)
     def last_sha(self, owner, repo, branch):
-        url = "%s/repository/branches/%s" % (self._repo_url(owner, repo), urllib.parse.quote_plus(str(branch)))
+        url = "%s/repository/branches/%s" % (self._repo_url(owner, repo), quote_plus(str(branch)))
         response = self.get(url)
         if not self._bad_response:
             data = response.json()
@@ -278,7 +283,7 @@ class GitLabAPI(GitAPI):
             return
 
         hook_url = '%s/hooks' % self._repo_url(repo.user.name, repo.name)
-        callback_url = urllib.parse.urljoin(self._civet_url, reverse('ci:gitlab:webhook', args=[user.build_key]))
+        callback_url = urljoin(self._civet_url, reverse('ci:gitlab:webhook', args=[user.build_key]))
         data = self.get_all_pages(hook_url)
 
         have_hook = False

--- a/ci/gitlab/api.py
+++ b/ci/gitlab/api.py
@@ -15,10 +15,10 @@
 
 from django.urls import reverse
 import logging
-import urllib, requests
+import urllib.request, urllib.parse, urllib.error, requests
 from ci.git_api import GitAPI, GitException, copydoc
 import re
-import urlparse
+import urllib.parse
 import json
 
 logger = logging.getLogger('ci')
@@ -69,7 +69,7 @@ class GitLabAPI(GitAPI):
 
     def _gitlab_id(self, owner, repo):
         name = '%s/%s' % (owner, repo)
-        return urllib.quote_plus(name)
+        return urllib.parse.quote_plus(name)
 
     def _repo_url(self, owner, repo):
         return '%s/projects/%s' % (self._api_url, self._gitlab_id(owner, repo))
@@ -89,7 +89,7 @@ class GitLabAPI(GitAPI):
             repo_id[int]: ID of the repo
             branch_id[int]: ID of the branch
         """
-        return "%s/projects/%s/repository/branches/%s" % (self._api_url, repo_id, urllib.quote_plus(str(branch_id)))
+        return "%s/projects/%s/repository/branches/%s" % (self._api_url, repo_id, urllib.parse.quote_plus(str(branch_id)))
 
     @copydoc(GitAPI.branch_html_url)
     def branch_html_url(self, owner, repo, branch):
@@ -258,7 +258,7 @@ class GitLabAPI(GitAPI):
 
     @copydoc(GitAPI.last_sha)
     def last_sha(self, owner, repo, branch):
-        url = "%s/repository/branches/%s" % (self._repo_url(owner, repo), urllib.quote_plus(str(branch)))
+        url = "%s/repository/branches/%s" % (self._repo_url(owner, repo), urllib.parse.quote_plus(str(branch)))
         response = self.get(url)
         if not self._bad_response:
             data = response.json()
@@ -278,7 +278,7 @@ class GitLabAPI(GitAPI):
             return
 
         hook_url = '%s/hooks' % self._repo_url(repo.user.name, repo.name)
-        callback_url = urlparse.urljoin(self._civet_url, reverse('ci:gitlab:webhook', args=[user.build_key]))
+        callback_url = urllib.parse.urljoin(self._civet_url, reverse('ci:gitlab:webhook', args=[user.build_key]))
         data = self.get_all_pages(hook_url)
 
         have_hook = False

--- a/ci/gitlab/oauth.py
+++ b/ci/gitlab/oauth.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci.oauth_api import OAuth
 from django.conf import settings
 from django.urls import reverse

--- a/ci/gitlab/tests/test_api.py
+++ b/ci/gitlab/tests/test_api.py
@@ -424,11 +424,11 @@ class Tests(DBTester.DBTester):
         pr0_ret = {"title": "some title", "number": 123, "html_url": "some url"}
         mock_get.return_value = utils.Response([pr0])
         prs = api.get_open_prs(repo.user.name, repo.name)
-        self.assertEquals([pr0_ret], prs)
+        self.assertEqual([pr0_ret], prs)
 
         mock_get.side_effect = Exception("BAM!")
         prs = api.get_open_prs(repo.user.name, repo.name)
-        self.assertEquals(prs, None)
+        self.assertEqual(prs, None)
 
     @patch.object(requests, 'put')
     @patch.object(requests, 'get')

--- a/ci/gitlab/tests/test_api.py
+++ b/ci/gitlab/tests/test_api.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.urls import reverse
 from django.conf import settings
 from django.test import override_settings

--- a/ci/gitlab/tests/test_oauth.py
+++ b/ci/gitlab/tests/test_oauth.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import TestCase, RequestFactory, Client
 from django.urls import reverse
 from django.conf import settings

--- a/ci/gitlab/tests/test_views.py
+++ b/ci/gitlab/tests/test_views.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.conf import settings
 from django.test import override_settings
 from django.urls import reverse
@@ -299,7 +300,7 @@ class Tests(DBTester.DBTester):
         response = self.client_post_json(url, push_data)
         self.assertEqual(response.status_code, 200)
         self.compare_counts(num_git_events=1)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
 
         push_data['ref'] = "refs/heads/%s" % self.branch.name
 
@@ -307,7 +308,7 @@ class Tests(DBTester.DBTester):
         response = self.client_post_json(url, push_data)
         self.assertEqual(response.status_code, 200)
         self.compare_counts(jobs=2, ready=1, events=1, commits=2, active=2, active_repos=1, num_git_events=1)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
 
         push_data['commits'] = []
 
@@ -316,5 +317,5 @@ class Tests(DBTester.DBTester):
         response = self.client_post_json(url, push_data)
         self.assertEqual(response.status_code, 200)
         self.compare_counts(num_git_events=1)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
         self.assertEqual(mock_get.call_count, 0)

--- a/ci/gitlab/urls.py
+++ b/ci/gitlab/urls.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.conf.urls import url
 from ci.gitlab import oauth, views
 

--- a/ci/gitlab/views.py
+++ b/ci/gitlab/views.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.views.decorators.csrf import csrf_exempt
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseNotAllowed
 import logging, traceback

--- a/ci/management/commands/disable_repo.py
+++ b/ci/management/commands/disable_repo.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+from __future__ import unicode_literals
 from django.core.management.base import BaseCommand, CommandError
 from ci import models
 

--- a/ci/management/commands/dump_latest.py
+++ b/ci/management/commands/dump_latest.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.core.management.base import BaseCommand
 from ci import models
 from django.core import serializers

--- a/ci/management/commands/generate_test_job_files.py
+++ b/ci/management/commands/generate_test_job_files.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.core.management.base import BaseCommand
 from ci.tests import utils
 from ci.client import views

--- a/ci/management/commands/load_recipes.py
+++ b/ci/management/commands/load_recipes.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.core.management.base import BaseCommand
 from ci.recipe import RecipeCreator
 from django.conf import settings

--- a/ci/management/commands/sync_open_prs.py
+++ b/ci/management/commands/sync_open_prs.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from django.core.management.base import BaseCommand, CommandError
 from ci import models
 
@@ -13,7 +14,7 @@ class Command(BaseCommand):
         else:
             r = repo.split("/")
             if len(r) != 2:
-                raise CommandError("Bad repo format. Should be <owner>/<repo_name>")
+                raise CommandError("Bad repo format '%s'. Should be <owner>/<repo_name>" % repo)
             repo_q = models.Repository.objects.filter(user__name=r[0], name=r[1], active=True)
         return repo_q
 

--- a/ci/management/commands/user_access.py
+++ b/ci/management/commands/user_access.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 
+from __future__ import unicode_literals
 from django.core.management.base import BaseCommand, CommandError
 from ci import models
 

--- a/ci/models.py
+++ b/ci/models.py
@@ -13,8 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.db import models
 from django.conf import settings
+from django.utils.encoding import python_2_unicode_compatible
 from ci.gitlab import api as gitlab_api
 from ci.gitlab import oauth as gitlab_auth
 from ci.bitbucket import api as bitbucket_api
@@ -68,6 +70,7 @@ class JobStatus(object):
     def to_slug(status):
         return JobStatus.SHORT_CHOICES[status][1]
 
+@python_2_unicode_compatible
 class GitServer(models.Model):
     """
     One of the git servers. The type for one of the main
@@ -82,7 +85,7 @@ class GitServer(models.Model):
     name = models.CharField(max_length=120, unique=True) # Name of the server, ex github.com
     host_type = models.IntegerField(choices=SERVER_TYPE)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     def server_config(self):
@@ -133,6 +136,7 @@ class GitServer(models.Model):
 def generate_build_key():
     return random.SystemRandom().randint(0, 2000000000)
 
+@python_2_unicode_compatible
 class GitUser(models.Model):
     """
     A user that will be signed into the system via
@@ -150,7 +154,7 @@ class GitUser(models.Model):
     # When loading the home page, only these repos will be shown
     preferred_repos = models.ManyToManyField("Repository", blank=True, related_name="users_with_preferences")
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     def start_session(self):
@@ -166,6 +170,7 @@ class GitUser(models.Model):
         unique_together = ['name', 'server']
         ordering = ['name']
 
+@python_2_unicode_compatible
 class Repository(models.Model):
     """
     For use in repositories on GitHub, etc. A typical structure is <user>/<repo>.
@@ -181,7 +186,7 @@ class Repository(models.Model):
     active = models.BooleanField(default=False)
     last_modified = models.DateTimeField(auto_now=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return "%s/%s" % (self.user.name, self.name)
 
     def server(self):
@@ -197,6 +202,7 @@ class Repository(models.Model):
     class Meta:
         unique_together = ['user', 'name']
 
+@python_2_unicode_compatible
 class Branch(models.Model):
     """
     A branch of a repository.
@@ -206,7 +212,7 @@ class Branch(models.Model):
     status = models.IntegerField(choices=JobStatus.STATUS_CHOICES, default=JobStatus.NOT_STARTED)
     last_modified = models.DateTimeField(auto_now=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return "{}:{}".format( str(self.repository), self.name)
 
     def user(self):
@@ -225,6 +231,7 @@ class Branch(models.Model):
     class Meta:
         unique_together = ['name', 'repository']
 
+@python_2_unicode_compatible
 class Commit(models.Model):
     """
     A particular commit in the git repository, identified by the hash.
@@ -233,7 +240,7 @@ class Commit(models.Model):
     sha = models.CharField(max_length=120)
     ssh_url = models.URLField(blank=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return "{}:{}".format(str(self.branch), self.short_sha())
 
     class Meta:
@@ -257,6 +264,7 @@ class Commit(models.Model):
         server = user.server
         return server.api().commit_html_url(user.name, repo.name, self.sha)
 
+@python_2_unicode_compatible
 class GitEvent(models.Model):
     """
     A web hook event. Store these in the database so that we can retry them if they failed.
@@ -273,7 +281,7 @@ class GitEvent(models.Model):
         ordering = ['-arrival_time']
         get_latest_by = 'arrival_time'
 
-    def __unicode__(self):
+    def __str__(self):
         if self.success:
             passed = "Success"
         else:
@@ -302,6 +310,7 @@ class GitEvent(models.Model):
         else:
             return JobStatus.to_slug(JobStatus.FAILED)
 
+@python_2_unicode_compatible
 class PullRequest(models.Model):
     """
     A pull request that was generated on a forked repository.
@@ -318,7 +327,7 @@ class PullRequest(models.Model):
     alternate_recipes = models.ManyToManyField("Recipe", blank=True, related_name="pull_requests")
     last_modified = models.DateTimeField(auto_now=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return '#{} : {}'.format(self.number, self.title)
 
     class Meta:
@@ -336,27 +345,7 @@ class PullRequest(models.Model):
         self.status = ev.status
         self.save()
 
-
-def sorted_job_compare(j1, j2):
-    """
-    Used to sort the jobs in an event group.
-    Sort by priorty, then name, then build config.
-    """
-    if j1.recipe.priority < j2.recipe.priority:
-        return 1
-    elif j1.recipe.priority > j2.recipe.priority:
-        return -1
-    elif j1.recipe.display_name < j2.recipe.display_name:
-        return -1
-    elif j1.recipe.display_name > j2.recipe.display_name:
-        return 1
-    elif j1.config.name < j2.config.name:
-        return -1
-    elif j1.config.name > j2.config.name:
-        return 1
-    else:
-        return 0
-
+@python_2_unicode_compatible
 class Event(models.Model):
     """
     Represents an event that has happened. For pull request and push, it
@@ -394,7 +383,7 @@ class Event(models.Model):
     last_modified = models.DateTimeField(auto_now=True)
     created = models.DateTimeField(db_index=True, auto_now_add=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return '{} : {}'.format(self.CAUSE_CHOICES[self.cause][1], str(self.head) )
 
     class Meta:
@@ -442,10 +431,11 @@ class Event(models.Model):
           dict: jobs are keys with a list of jobs as values
         """
         depends_on = {}
-        for j in self.jobs.all():
+        all_jobs = [j for j in self.jobs.all()]
+        for j in all_jobs:
             deps = []
             for r in j.recipe.depends_on.all():
-                for j2 in self.jobs.all():
+                for j2 in all_jobs:
                     if j2 != j and j2.recipe.filename == r.filename:
                         deps.append(j2)
             depends_on[j] = deps
@@ -474,6 +464,16 @@ class Event(models.Model):
             if not added:
                 break
         return wont_run
+
+    @staticmethod
+    def sorted_jobs(jobs):
+        # Take advantage of python stable sorting
+        # This used to be in a cmp() style function but python3 removed it.
+        jobs = sorted(jobs, key=lambda obj: obj.pk)
+        jobs = sorted(jobs, key=lambda obj: obj.config.name)
+        jobs = sorted(jobs, key=lambda obj: obj.recipe.display_name)
+        jobs = sorted(jobs, key=lambda obj: obj.recipe.priority, reverse=True)
+        return jobs
 
     def get_sorted_jobs(self):
         """
@@ -506,7 +506,7 @@ class Event(models.Model):
             else:
                 other = new_other
             added_jobs |= set(new_group)
-            job_groups.append(sorted(new_group, cmp=sorted_job_compare))
+            job_groups.append(self.sorted_jobs(new_group))
 
         return job_groups
 
@@ -604,6 +604,7 @@ class Event(models.Model):
                 job.save()
                 logger.info('Job {}: {} : ready: {} : on {}'.format(job.pk, job, job.ready, job.recipe.repository))
 
+@python_2_unicode_compatible
 class BuildConfig(models.Model):
     """
     Different names for build configurations.
@@ -612,7 +613,7 @@ class BuildConfig(models.Model):
     """
     name = models.CharField(max_length=120)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 class RecipeRepository(models.Model):
@@ -645,6 +646,7 @@ class RecipeRepository(models.Model):
         except cls.DoesNotExist:
             return cls.objects.create(sha="")
 
+@python_2_unicode_compatible
 class Recipe(models.Model):
     """
     Holds information about a recipe.
@@ -696,7 +698,7 @@ class Recipe(models.Model):
     last_modified = models.DateTimeField(auto_now=True)
     created = models.DateTimeField(auto_now_add=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     class Meta:
@@ -719,6 +721,7 @@ class Recipe(models.Model):
     def auto_str(self):
         return self.AUTO_CHOICES[self.automatic][1]
 
+@python_2_unicode_compatible
 class RecipeViewableByTeam(models.Model):
     """
     A team name that can view a job
@@ -727,12 +730,13 @@ class RecipeViewableByTeam(models.Model):
     team = models.CharField(max_length=120)
     git_id = models.IntegerField(default=0) # The ID for use with the Git API
 
-    def __unicode__(self):
+    def __str__(self):
         return self.team
 
     class Meta:
         unique_together = ['recipe', 'team']
 
+@python_2_unicode_compatible
 class RecipeEnvironment(models.Model):
     """
     Name value pairs to be inserted into the environment
@@ -742,9 +746,10 @@ class RecipeEnvironment(models.Model):
     name = models.CharField(max_length=120)
     value = models.CharField(max_length=120)
 
-    def __unicode__(self):
-        return '{}={}'.format( self.name, self.value )
+    def __str__(self):
+        return '{}={}'.format(self.name, self.value)
 
+@python_2_unicode_compatible
 class PreStepSource(models.Model):
     """
     Since we use bash to execute our steps, we can just add some
@@ -755,10 +760,10 @@ class PreStepSource(models.Model):
     recipe = models.ForeignKey(Recipe, related_name='prestepsources', on_delete=models.CASCADE)
     filename = models.CharField(max_length=120, blank=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.filename
 
-
+@python_2_unicode_compatible
 class Step(models.Model):
     """
     A specific step in a recipe. The filename points to a specific script
@@ -774,12 +779,13 @@ class Step(models.Model):
     abort_on_failure = models.BooleanField(default=True)
     allowed_to_fail = models.BooleanField(default=False)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     class Meta:
         ordering = ['position',]
 
+@python_2_unicode_compatible
 class StepEnvironment(models.Model):
     """
     Name value pairs to be inserted into the environment
@@ -789,9 +795,10 @@ class StepEnvironment(models.Model):
     name = models.CharField(max_length=120)
     value = models.CharField(max_length=120)
 
-    def __unicode__(self):
-        return '{}:{}'.format( self.name, self.value )
+    def __str__(self):
+        return '{}:{}'.format(self.name, self.value)
 
+@python_2_unicode_compatible
 class Client(models.Model):
     """
     Represents a client that is run on the build servers. Since the
@@ -816,7 +823,7 @@ class Client(models.Model):
     last_seen = models.DateTimeField(auto_now=True)
     created = models.DateTimeField(auto_now_add=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     def status_str(self):
@@ -831,6 +838,7 @@ class Client(models.Model):
     class Meta:
         get_latest_by = 'last_seen'
 
+@python_2_unicode_compatible
 class OSVersion(models.Model):
     """
     The name and version of the operating system while a job is running.
@@ -840,9 +848,10 @@ class OSVersion(models.Model):
     other = models.CharField(max_length=120, blank=True)
     created = models.DateTimeField(auto_now_add=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return "%s %s" % (self.name, self.version)
 
+@python_2_unicode_compatible
 class LoadedModule(models.Model):
     """
     A module loaded while a job is running
@@ -850,7 +859,7 @@ class LoadedModule(models.Model):
     name = models.CharField(max_length=120)
     created = models.DateTimeField(auto_now_add=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 def humanize_bytes(num):
@@ -860,6 +869,7 @@ def humanize_bytes(num):
         num /= 1024.0
     return "%.1f YiB" % num
 
+@python_2_unicode_compatible
 class Job(models.Model):
     """
     Represents the execution of a single config of a Recipe.
@@ -882,7 +892,7 @@ class Job(models.Model):
     last_modified = models.DateTimeField(auto_now=True)
     created = models.DateTimeField(auto_now_add=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return '{}:{}'.format(self.recipe.name, self.config.name)
 
     def status_slug(self):
@@ -950,6 +960,7 @@ class Job(models.Model):
         get_latest_by = 'last_modified'
         unique_together = ['recipe', 'event', 'config']
 
+@python_2_unicode_compatible
 class JobTestStatistics(models.Model):
     """
     Number of tests run, failed, passed, skipped for a job.
@@ -960,9 +971,10 @@ class JobTestStatistics(models.Model):
     skipped = models.IntegerField(default=0)
     created = models.DateTimeField(auto_now_add=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return "%s passed, %s failed, %s skipped" % (self.passed, self.failed, self.skipped)
 
+@python_2_unicode_compatible
 class JobChangeLog(models.Model):
     """
     Holds information about changes of status to the job.
@@ -973,7 +985,7 @@ class JobChangeLog(models.Model):
     notes = models.TextField(blank=True) # Additional information
     created = models.DateTimeField(auto_now_add=True)
 
-    def __unicode__(self):
+    def __str__(self):
         out = "%s - %s" % (self.message, TimeUtils.display_time_str(self.created))
         return out
 
@@ -995,6 +1007,7 @@ def terminalize_output(output):
     conv = ansi2html.Ansi2HTMLConverter(escaped=False, scheme="xterm")
     return conv.convert(output, full=False)
 
+@python_2_unicode_compatible
 class StepResult(models.Model):
     """
     The result of a single step of a Recipe for a single Job.
@@ -1019,7 +1032,7 @@ class StepResult(models.Model):
     seconds = models.DurationField(default=timedelta) #run time
     last_modified = models.DateTimeField(auto_now=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return '{}:{}'.format(self.job, self.name)
 
     class Meta:
@@ -1036,8 +1049,9 @@ class StepResult(models.Model):
         return terminalize_output(self.output)
 
     def plain_output(self):
-        new_out = re.sub("\33\[1m", "", self.output)
-        new_out = re.sub("\33\[(1;)*(\d{1,2})m", "", new_out)
+        prefix = re.escape("\33[")
+        new_out = re.sub(prefix + r"1m", "", self.output)
+        new_out = re.sub(prefix + r"(1;)*(\d{1,2})m", "", new_out)
         return new_out
 
     def output_size(self):

--- a/ci/models.py
+++ b/ci/models.py
@@ -24,7 +24,7 @@ from ci.github import oauth as github_auth
 import random, re
 from django.utils import timezone
 from datetime import timedelta, datetime
-import TimeUtils
+from . import TimeUtils
 import json
 import ansi2html
 import logging
@@ -319,7 +319,7 @@ class PullRequest(models.Model):
     last_modified = models.DateTimeField(auto_now=True)
 
     def __unicode__(self):
-        return u'#{} : {}'.format(self.number, self.title)
+        return '#{} : {}'.format(self.number, self.title)
 
     class Meta:
         get_latest_by = 'last_modified'
@@ -395,7 +395,7 @@ class Event(models.Model):
     created = models.DateTimeField(db_index=True, auto_now_add=True)
 
     def __unicode__(self):
-        return u'{} : {}'.format(self.CAUSE_CHOICES[self.cause][1], str(self.head) )
+        return '{} : {}'.format(self.CAUSE_CHOICES[self.cause][1], str(self.head) )
 
     class Meta:
         ordering = ['-created']
@@ -464,7 +464,7 @@ class Event(models.Model):
         # we want the list to have j1 and j2.
         while True:
             added = False
-            for job, deps in depends.iteritems():
+            for job, deps in depends.items():
                 if job in wont_run:
                     continue
                 for d in deps:
@@ -487,7 +487,7 @@ class Event(models.Model):
         other = []
         job_groups = []
 
-        other = job_depends.keys()
+        other = list(job_depends.keys())
         while other:
             new_other = []
             new_group = []
@@ -589,7 +589,7 @@ class Event(models.Model):
             return
 
         job_depends = self.get_job_depends_on()
-        for job, deps in job_depends.iteritems():
+        for job, deps in job_depends.items():
             if job.complete or job.ready or not job.active:
                 continue
             ready = True
@@ -743,7 +743,7 @@ class RecipeEnvironment(models.Model):
     value = models.CharField(max_length=120)
 
     def __unicode__(self):
-        return u'{}={}'.format( self.name, self.value )
+        return '{}={}'.format( self.name, self.value )
 
 class PreStepSource(models.Model):
     """
@@ -790,7 +790,7 @@ class StepEnvironment(models.Model):
     value = models.CharField(max_length=120)
 
     def __unicode__(self):
-        return u'{}:{}'.format( self.name, self.value )
+        return '{}:{}'.format( self.name, self.value )
 
 class Client(models.Model):
     """
@@ -883,7 +883,7 @@ class Job(models.Model):
     created = models.DateTimeField(auto_now_add=True)
 
     def __unicode__(self):
-        return u'{}:{}'.format(self.recipe.name, self.config.name)
+        return '{}:{}'.format(self.recipe.name, self.config.name)
 
     def status_slug(self):
         if not self.active and self.status == JobStatus.NOT_STARTED:
@@ -1020,7 +1020,7 @@ class StepResult(models.Model):
     last_modified = models.DateTimeField(auto_now=True)
 
     def __unicode__(self):
-        return u'{}:{}'.format(self.job, self.name)
+        return '{}:{}'.format(self.job, self.name)
 
     class Meta:
         unique_together = ['job', 'position']

--- a/ci/oauth_api.py
+++ b/ci/oauth_api.py
@@ -58,7 +58,7 @@ class OAuth(object):
         self._config = server.server_config()
         if not self._config:
             raise OAuthException("Git server %s (%s) is not configured" % (server, server.api_type()))
-        self._prefix = "%s_" % self._config["hostname"]
+        self._prefix = "%s_" % self._config.get("hostname", "unknown_host")
         self._token_key = "%s_token" % self._prefix
         self._user_key = "%s_user" % self._prefix
         self._state_key = "%s_state" % self._prefix

--- a/ci/oauth_api.py
+++ b/ci/oauth_api.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.shortcuts import redirect
 from requests_oauthlib import OAuth2Session
 from django.contrib import messages

--- a/ci/oauth_api.py
+++ b/ci/oauth_api.py
@@ -302,7 +302,7 @@ class OAuth(object):
             messages.info(request, msg)
             logger.info(msg)
 
-        for key in request.session.keys():
+        for key in list(request.session.keys()):
             if key.startswith(self._prefix):
                 request.session.pop(key, None)
 

--- a/ci/recipe/RecipeCreator.py
+++ b/ci/recipe/RecipeCreator.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.conf import settings
 from django.db import transaction
 from . import file_utils
@@ -55,7 +56,7 @@ class RecipeCreator(object):
         try:
             self._repo_reader = RecipeRepoReader.RecipeRepoReader(self._recipes_dir)
         except Exception as e:
-            print(("Failed to load RecipeRepoReader: %s" % e))
+            print("Failed to load RecipeRepoReader: %s" % e)
             raise e
 
     def _sort_recipes(self):
@@ -108,11 +109,11 @@ class RecipeCreator(object):
 
         to_remove = current_filenames - all_filenames
         if to_remove:
-            print(("\tNo longer active:\n\t\t%s" % "\n\t\t".join(sorted(to_remove))))
+            print("\tNo longer active:\n\t\t%s" % "\n\t\t".join(sorted(to_remove)))
         if new_files:
-            print(("\tNew recipes:\n\t\t%s" % "\n\t\t".join(sorted(new_files))))
+            print("\tNew recipes:\n\t\t%s" % "\n\t\t".join(sorted(new_files)))
         if changed_files:
-            print(("\tChanged recipes:\n\t\t%s" % "\n\t\t".join(sorted(changed_files))))
+            print("\tChanged recipes:\n\t\t%s" % "\n\t\t".join(sorted(changed_files)))
 
         if not dryrun:
             for fname in to_remove:
@@ -165,10 +166,10 @@ class RecipeCreator(object):
         Return:
             tuple(int, int, int): (removed, new, changed)
         """
-        print(("%s reading recipes from %s %s" % ("-"*20, self._recipes_dir, "-"*20)))
+        print("%s reading recipes from %s %s" % ("-"*20, self._recipes_dir, "-"*20))
 
         if not force and self._repo_sha == self._recipe_repo_rec.sha:
-            print(("Repo the same, not loading recipes: %s" % self._repo_sha[:8]))
+            print("Repo the same, not loading recipes: %s" % self._repo_sha[:8])
             return 0, 0, 0
 
         removed = 0
@@ -182,7 +183,7 @@ class RecipeCreator(object):
                     owner_rec, created = models.GitUser.objects.get_or_create(name=owner, server=server_rec)
                     for repo, recipes in repo_dict.items():
                         repo_rec, created = models.Repository.objects.get_or_create(name=repo, user=owner_rec)
-                        print(("%s: %s:%s" % (build_user_rec, server_rec, repo_rec)))
+                        print("%s: %s:%s" % (build_user_rec, server_rec, repo_rec))
                         r, n, c = self._update_repo_recipes(recipes, build_user_rec, repo_rec, dryrun)
                         removed += r
                         new += n
@@ -201,7 +202,7 @@ class RecipeCreator(object):
         for server in settings.INSTALLED_GITSERVERS:
             server_rec, created = models.GitServer.objects.get_or_create(host_type=server["type"], name=server["hostname"])
             if not server_rec.server_config().get("install_webhook", False):
-                print(("Not trying to install/update webhooks for %s" % server_rec))
+                print("Not trying to install/update webhooks for %s" % server_rec)
                 continue
 
             for build_user, owners_dict in self._sorted_recipes.get(server_rec.name, {}).items():
@@ -213,11 +214,11 @@ class RecipeCreator(object):
                         repo_rec, created = models.Repository.objects.get_or_create(name=repo, user=owner_rec)
                         try:
                             api.install_webhooks(build_user_rec, repo_rec)
-                            print(("Webhook in place for %s" % repo_rec))
+                            print("Webhook in place for %s" % repo_rec)
                         except Exception as e:
                             # We might not have direct access to install a webhook, which is fine
                             # if the repo is owned by non INL
-                            print(("FAILED to install webhook for %s:\n%s" % (repo_rec, e)))
+                            print("FAILED to install webhook for %s:\n%s" % (repo_rec, e))
 
     def _get_new_recipe(self, recipe, build_user, repo, branch, cause):
         recipe_rec, created = models.Recipe.objects.get_or_create(

--- a/ci/recipe/RecipeCreator.py
+++ b/ci/recipe/RecipeCreator.py
@@ -15,9 +15,9 @@
 
 from django.conf import settings
 from django.db import transaction
-import file_utils
+from . import file_utils
 from ci import models
-import RecipeRepoReader
+from . import RecipeRepoReader
 
 class RecipeCreator(object):
     """
@@ -55,7 +55,7 @@ class RecipeCreator(object):
         try:
             self._repo_reader = RecipeRepoReader.RecipeRepoReader(self._recipes_dir)
         except Exception as e:
-            print("Failed to load RecipeRepoReader: %s" % e)
+            print(("Failed to load RecipeRepoReader: %s" % e))
             raise e
 
     def _sort_recipes(self):
@@ -108,11 +108,11 @@ class RecipeCreator(object):
 
         to_remove = current_filenames - all_filenames
         if to_remove:
-            print("\tNo longer active:\n\t\t%s" % "\n\t\t".join(sorted(to_remove)))
+            print(("\tNo longer active:\n\t\t%s" % "\n\t\t".join(sorted(to_remove))))
         if new_files:
-            print("\tNew recipes:\n\t\t%s" % "\n\t\t".join(sorted(new_files)))
+            print(("\tNew recipes:\n\t\t%s" % "\n\t\t".join(sorted(new_files))))
         if changed_files:
-            print("\tChanged recipes:\n\t\t%s" % "\n\t\t".join(sorted(changed_files)))
+            print(("\tChanged recipes:\n\t\t%s" % "\n\t\t".join(sorted(changed_files))))
 
         if not dryrun:
             for fname in to_remove:
@@ -165,10 +165,10 @@ class RecipeCreator(object):
         Return:
             tuple(int, int, int): (removed, new, changed)
         """
-        print("%s reading recipes from %s %s" % ("-"*20, self._recipes_dir, "-"*20))
+        print(("%s reading recipes from %s %s" % ("-"*20, self._recipes_dir, "-"*20)))
 
         if not force and self._repo_sha == self._recipe_repo_rec.sha:
-            print("Repo the same, not loading recipes: %s" % self._repo_sha[:8])
+            print(("Repo the same, not loading recipes: %s" % self._repo_sha[:8]))
             return 0, 0, 0
 
         removed = 0
@@ -176,13 +176,13 @@ class RecipeCreator(object):
         changed = 0
         for server in settings.INSTALLED_GITSERVERS:
             server_rec, created = models.GitServer.objects.get_or_create(host_type=server["type"], name=server["hostname"])
-            for build_user, owners_dict in self._sorted_recipes.get(server_rec.name, {}).iteritems():
+            for build_user, owners_dict in self._sorted_recipes.get(server_rec.name, {}).items():
                 build_user_rec, created = models.GitUser.objects.get_or_create(name=build_user, server=server_rec)
-                for owner, repo_dict in owners_dict.iteritems():
+                for owner, repo_dict in owners_dict.items():
                     owner_rec, created = models.GitUser.objects.get_or_create(name=owner, server=server_rec)
-                    for repo, recipes in repo_dict.iteritems():
+                    for repo, recipes in repo_dict.items():
                         repo_rec, created = models.Repository.objects.get_or_create(name=repo, user=owner_rec)
-                        print("%s: %s:%s" % (build_user_rec, server_rec, repo_rec))
+                        print(("%s: %s:%s" % (build_user_rec, server_rec, repo_rec)))
                         r, n, c = self._update_repo_recipes(recipes, build_user_rec, repo_rec, dryrun)
                         removed += r
                         new += n
@@ -201,23 +201,23 @@ class RecipeCreator(object):
         for server in settings.INSTALLED_GITSERVERS:
             server_rec, created = models.GitServer.objects.get_or_create(host_type=server["type"], name=server["hostname"])
             if not server_rec.server_config().get("install_webhook", False):
-                print("Not trying to install/update webhooks for %s" % server_rec)
+                print(("Not trying to install/update webhooks for %s" % server_rec))
                 continue
 
-            for build_user, owners_dict in self._sorted_recipes.get(server_rec.name, {}).iteritems():
+            for build_user, owners_dict in self._sorted_recipes.get(server_rec.name, {}).items():
                 build_user_rec, created = models.GitUser.objects.get_or_create(name=build_user, server=server_rec)
                 api = build_user_rec.api()
-                for owner, repo_dict in owners_dict.iteritems():
+                for owner, repo_dict in owners_dict.items():
                     owner_rec, created = models.GitUser.objects.get_or_create(name=owner, server=server_rec)
-                    for repo, recipes in repo_dict.iteritems():
+                    for repo, recipes in repo_dict.items():
                         repo_rec, created = models.Repository.objects.get_or_create(name=repo, user=owner_rec)
                         try:
                             api.install_webhooks(build_user_rec, repo_rec)
-                            print("Webhook in place for %s" % repo_rec)
+                            print(("Webhook in place for %s" % repo_rec))
                         except Exception as e:
                             # We might not have direct access to install a webhook, which is fine
                             # if the repo is owned by non INL
-                            print("FAILED to install webhook for %s:\n%s" % (repo_rec, e))
+                            print(("FAILED to install webhook for %s:\n%s" % (repo_rec, e)))
 
     def _get_new_recipe(self, recipe, build_user, repo, branch, cause):
         recipe_rec, created = models.Recipe.objects.get_or_create(
@@ -283,7 +283,7 @@ class RecipeCreator(object):
             allowed_to_fail=step_dict["allowed_to_fail"],
             )
         if created:
-            for name, value in step_dict["environment"].iteritems():
+            for name, value in step_dict["environment"].items():
                 step_env, created = models.StepEnvironment.objects.get_or_create(step=step_rec, name=name, value=value)
         return step_rec
 
@@ -294,7 +294,7 @@ class RecipeCreator(object):
           recipe_rec: models.Recipe: Recipe to attach step to.
           recipe_dict: dict: A recipe dictionary as produced by RecipeReader
         """
-        for name, value in recipe_dict["global_env"].iteritems():
+        for name, value in recipe_dict["global_env"].items():
             recipe_env, created = models.RecipeEnvironment.objects.get_or_create(recipe=recipe_rec, name=name, value=value)
 
     def _create_prestep(self, recipe_rec, recipe_dict):

--- a/ci/recipe/RecipeReader.py
+++ b/ci/recipe/RecipeReader.py
@@ -13,9 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import configparser
-from . import file_utils
+from __future__ import unicode_literals
 import os, re
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
+from . import file_utils
+
 
 class RecipeReader(object):
     """
@@ -46,12 +51,14 @@ class RecipeReader(object):
         # for environment variables
         self.config.optionxform = str
 
-        with open(os.path.join(recipe_dir, filename), "r") as f:
-            self.config.readfp(f)
+        fname = os.path.join(recipe_dir, filename)
+        valid_files = self.config.read([fname])
+        if not valid_files:
+            raise configparser.Error("Bad filename: %s" % fname)
         self.recipe = {}
 
     def error(self, msg):
-        print(("%s/%s: %s" % (self.recipe_dir, self.filename, msg)))
+        print("%s/%s: %s" % (self.recipe_dir, self.filename, msg))
 
     def get_option(self, section, option, default):
         """
@@ -345,19 +352,19 @@ class RecipeReader(object):
         Return:
           hostname, owner, repository
         """
-        r = re.match("git@(.+):(.+)/(.+)\.git", repo)
+        r = re.match(r"git@(.+):(.+)/(.+)\.git", repo)
         if r:
             return r.group(1), r.group(2), r.group(3)
 
-        r = re.match("git@(.+):(.+)/(.+)", repo)
+        r = re.match(r"git@(.+):(.+)/(.+)", repo)
         if r:
             return r.group(1), r.group(2), r.group(3)
 
-        r = re.match("https://(.+)/(.+)/(.+).git", repo)
+        r = re.match(r"https://(.+)/(.+)/(.+).git", repo)
         if r:
             return r.group(1), r.group(2), r.group(3)
 
-        r = re.match("https://(.+)/(.+)/(.+)", repo)
+        r = re.match(r"https://(.+)/(.+)/(.+)", repo)
         if r:
             return r.group(1), r.group(2), r.group(3)
 
@@ -378,8 +385,8 @@ if __name__ == "__main__":
         reader = RecipeReader(parent_dir, rel_path)
         recipe = reader.read()
         if recipe:
-            print((json.dumps(recipe, indent=2)))
+            print(json.dumps(recipe, indent=2))
         else:
-            print(("Recipe '%s' is not valid" % real_path))
+            print("Recipe '%s' is not valid" % real_path)
     except Exception as e:
-        print(("Recipe '%s' is not valid: %s" % (real_path, e)))
+        print("Recipe '%s' is not valid: %s" % (real_path, e))

--- a/ci/recipe/RecipeReader.py
+++ b/ci/recipe/RecipeReader.py
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ConfigParser
-import file_utils
+import configparser
+from . import file_utils
 import os, re
 
 class RecipeReader(object):
@@ -40,7 +40,7 @@ class RecipeReader(object):
                 "Release Dependencies",
                 "Global Environment",
                 ]
-        self.config = ConfigParser.RawConfigParser()
+        self.config = configparser.RawConfigParser()
         # ConfigParser will default to having case insensitive options and
         # returning lower case versions of options. This is not good
         # for environment variables
@@ -51,7 +51,7 @@ class RecipeReader(object):
         self.recipe = {}
 
     def error(self, msg):
-        print("%s/%s: %s" % (self.recipe_dir, self.filename, msg))
+        print(("%s/%s: %s" % (self.recipe_dir, self.filename, msg)))
 
     def get_option(self, section, option, default):
         """
@@ -79,10 +79,10 @@ class RecipeReader(object):
                 val = self.config.get(section, option)
 
             return val
-        except ConfigParser.NoSectionError:
+        except configparser.NoSectionError:
             self.error("Section '%s' does not exist. Failed to get option '%s'" % (section, option))
             return default
-        except ConfigParser.NoOptionError:
+        except configparser.NoOptionError:
             #self.error("Failed to get option '%s' in section '%s'" % (option, section))
             return default
         except ValueError:
@@ -378,8 +378,8 @@ if __name__ == "__main__":
         reader = RecipeReader(parent_dir, rel_path)
         recipe = reader.read()
         if recipe:
-            print(json.dumps(recipe, indent=2))
+            print((json.dumps(recipe, indent=2)))
         else:
-            print("Recipe '%s' is not valid" % real_path)
+            print(("Recipe '%s' is not valid" % real_path))
     except Exception as e:
-        print("Recipe '%s' is not valid: %s" % (real_path, e))
+        print(("Recipe '%s' is not valid: %s" % (real_path, e)))

--- a/ci/recipe/RecipeRepoReader.py
+++ b/ci/recipe/RecipeRepoReader.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import os, fnmatch
 from .RecipeReader import RecipeReader
 
@@ -99,7 +100,7 @@ class RecipeRepoReader(object):
                         or dep_recipe["build_user"] != recipe["build_user"]
                         or dep_recipe["repository"] != recipe["repository"]
                         or not dep_recipe[trigger_key]):
-                        print(("Recipe: %s: has invalid %s : %s" % (recipe["filename"], dep_key, dep)))
+                        print("Recipe: %s: has invalid %s : %s" % (recipe["filename"], dep_key, dep))
                         ret = False
                     break
         return ret
@@ -112,4 +113,4 @@ if __name__ == "__main__":
         reader = RecipeRepoReader(parent_dir)
         #print(json.dumps(reader.recipes, indent=2))
     except Exception as e:
-        print(("Recipe repo is not valid: %s" % e))
+        print("Recipe repo is not valid: %s" % e)

--- a/ci/recipe/RecipeRepoReader.py
+++ b/ci/recipe/RecipeRepoReader.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import os, fnmatch
-from RecipeReader import RecipeReader
+from .RecipeReader import RecipeReader
 
 class InvalidDependency(Exception):
     pass
@@ -99,7 +99,7 @@ class RecipeRepoReader(object):
                         or dep_recipe["build_user"] != recipe["build_user"]
                         or dep_recipe["repository"] != recipe["repository"]
                         or not dep_recipe[trigger_key]):
-                        print("Recipe: %s: has invalid %s : %s" % (recipe["filename"], dep_key, dep))
+                        print(("Recipe: %s: has invalid %s : %s" % (recipe["filename"], dep_key, dep)))
                         ret = False
                     break
         return ret
@@ -112,4 +112,4 @@ if __name__ == "__main__":
         reader = RecipeRepoReader(parent_dir)
         #print(json.dumps(reader.recipes, indent=2))
     except Exception as e:
-        print("Recipe repo is not valid: %s" % e)
+        print(("Recipe repo is not valid: %s" % e))

--- a/ci/recipe/RecipeWriter.py
+++ b/ci/recipe/RecipeWriter.py
@@ -13,10 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import configparser
+from __future__ import unicode_literals
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 import os
 from . import file_utils
-import io
 
 def add_list(config, recipe, recipe_key, section, prefix):
     l = recipe.get(recipe_key, [])
@@ -42,7 +49,7 @@ def write_recipe_to_string(recipe):
             if isinstance(value, list):
                 config.set("Main", key, ','.join(value))
             else:
-                config.set("Main", key, value)
+                config.set("Main", key, str(value))
 
     add_list(config, recipe, "pullrequest_dependencies", "PullRequest Dependencies", "recipe")
     add_list(config, recipe, "push_dependencies", "Push Dependencies", "recipe")
@@ -61,10 +68,10 @@ def write_recipe_to_string(recipe):
         config.add_section(name)
         for key, value in step.items():
             if key != "name" and key != "environment" and key != "position":
-                config.set(name, key, value)
+                config.set(name, key, str(value))
         for key, value in step["environment"].items():
-            config.set(name, key, value)
-    output = io.StringIO()
+            config.set(name, key, str(value))
+    output = StringIO()
     config.write(output)
     return output.getvalue()
 
@@ -80,7 +87,7 @@ def write_recipe_to_repo(repo_dir, recipe, filename):
     """
     full_path = os.path.join(repo_dir, filename)
     if not file_utils.is_subdir(full_path, repo_dir):
-        print(("Not a valid recipe filename: %s" % filename))
+        print("Not a valid recipe filename: %s" % filename)
         return False
 
     data = write_recipe_to_string(recipe)

--- a/ci/recipe/RecipeWriter.py
+++ b/ci/recipe/RecipeWriter.py
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ConfigParser
+import configparser
 import os
-import file_utils
-import StringIO
+from . import file_utils
+import io
 
 def add_list(config, recipe, recipe_key, section, prefix):
     l = recipe.get(recipe_key, [])
@@ -26,7 +26,7 @@ def add_list(config, recipe, recipe_key, section, prefix):
         config.set(section, "%s%s" % (prefix, i), dep)
 
 def write_recipe_to_string(recipe):
-    config = ConfigParser.ConfigParser()
+    config = configparser.ConfigParser()
     config.optionxform = str
     config.add_section("Main")
     sections = ["steps",
@@ -37,7 +37,7 @@ def write_recipe_to_string(recipe):
             "push_dependencies",
             ]
 
-    for key, value in recipe.iteritems():
+    for key, value in recipe.items():
         if key not in sections:
             if isinstance(value, list):
                 config.set("Main", key, ','.join(value))
@@ -52,19 +52,19 @@ def write_recipe_to_string(recipe):
     global_env = recipe.get("global_env", {})
     if global_env:
         config.add_section("Global Environment")
-    for key, value in global_env.iteritems():
+    for key, value in global_env.items():
         config.set("Global Environment", key, value)
 
     steps = recipe.get("steps", [])
     for step in steps:
         name = step["name"]
         config.add_section(name)
-        for key, value in step.iteritems():
+        for key, value in step.items():
             if key != "name" and key != "environment" and key != "position":
                 config.set(name, key, value)
-        for key, value in step["environment"].iteritems():
+        for key, value in step["environment"].items():
             config.set(name, key, value)
-    output = StringIO.StringIO()
+    output = io.StringIO()
     config.write(output)
     return output.getvalue()
 
@@ -80,7 +80,7 @@ def write_recipe_to_repo(repo_dir, recipe, filename):
     """
     full_path = os.path.join(repo_dir, filename)
     if not file_utils.is_subdir(full_path, repo_dir):
-        print("Not a valid recipe filename: %s" % filename)
+        print(("Not a valid recipe filename: %s" % filename))
         return False
 
     data = write_recipe_to_string(recipe)

--- a/ci/recipe/file_utils.py
+++ b/ci/recipe/file_utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import os
 import subprocess
 
@@ -77,9 +78,9 @@ def get_repo_sha(base_dir):
     """
     try:
         sha = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=base_dir)
-        return sha.strip()
+        return sha.decode("utf-8").strip()
     except Exception as e:
-        print(("Failed to get repo sha for '%s': %s" % (base_dir, e)))
+        print("Failed to get repo sha for '%s': %s" % (base_dir, e))
         return ""
 
 def get_file_sha(repo_dir, filename):
@@ -96,7 +97,7 @@ def get_file_sha(repo_dir, filename):
         if not sha:
             return ""
         sha = subprocess.check_output(['git', 'hash-object', filename], cwd=repo_dir)
-        return sha.strip()
+        return sha.decode("utf-8").strip()
     except Exception as e:
-        print(("Failed to get sha for '%s/%s': %s" % (repo_dir, filename, e)))
+        print("Failed to get sha for '%s/%s': %s" % (repo_dir, filename, e))
         return ""

--- a/ci/recipe/file_utils.py
+++ b/ci/recipe/file_utils.py
@@ -79,7 +79,7 @@ def get_repo_sha(base_dir):
         sha = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=base_dir)
         return sha.strip()
     except Exception as e:
-        print("Failed to get repo sha for '%s': %s" % (base_dir, e))
+        print(("Failed to get repo sha for '%s': %s" % (base_dir, e)))
         return ""
 
 def get_file_sha(repo_dir, filename):
@@ -98,5 +98,5 @@ def get_file_sha(repo_dir, filename):
         sha = subprocess.check_output(['git', 'hash-object', filename], cwd=repo_dir)
         return sha.strip()
     except Exception as e:
-        print("Failed to get sha for '%s/%s': %s" % (repo_dir, filename, e))
+        print(("Failed to get sha for '%s/%s': %s" % (repo_dir, filename, e)))
         return ""

--- a/ci/recipe/recipe_to_bash.py
+++ b/ci/recipe/recipe_to_bash.py
@@ -17,6 +17,7 @@
 Converts a recipe given in a .cfg file into a full bash shell script
 which would be similar to what CIVET would end up running.
 """
+from __future__ import unicode_literals
 import argparse, sys, os
 import re
 from .RecipeReader import RecipeReader
@@ -142,7 +143,7 @@ def convert_recipe(args):
         reader = RecipeReader(parent_dir, rel_path)
         recipe = reader.read()
     except Exception as e:
-        print(("Recipe '%s' is not valid: %s" % (real_path, e)))
+        print("Recipe '%s' is not valid: %s" % (real_path, e))
         return 1
     try:
         script = recipe_to_bash(recipe,
@@ -165,7 +166,7 @@ def convert_recipe(args):
         else:
             print(script)
     except Exception as e:
-        print(("Failed to convert recipe: %s" % e))
+        print("Failed to convert recipe: %s" % e)
         return 1
 
 if __name__ == "__main__":

--- a/ci/recipe/recipe_to_bash.py
+++ b/ci/recipe/recipe_to_bash.py
@@ -19,7 +19,7 @@ which would be similar to what CIVET would end up running.
 """
 import argparse, sys, os
 import re
-from RecipeReader import RecipeReader
+from .RecipeReader import RecipeReader
 
 def read_script(filename):
     top_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
@@ -32,7 +32,7 @@ def step_functions(recipe):
     step_cmds = ''
     for step in recipe["steps"]:
         step_cmds += "function step_%s\n{\n" % step["position"]
-        for key, value in step["environment"].items():
+        for key, value in list(step["environment"].items()):
             step_cmds += write_env(key, value, "  local")
         step_cmds += '  local step_name="%s"\n' % step["name"]
         step_cmds += '  local step_position="%s"\n' % step["position"]
@@ -113,7 +113,7 @@ def recipe_to_bash(recipe,
         script += "# %s\n%s\n" % (source, s)
 
     script += "\n\n"
-    for key, value in recipe["global_env"].items():
+    for key, value in list(recipe["global_env"].items()):
         script += write_env(key, value)
 
     script += "\n\n"
@@ -142,7 +142,7 @@ def convert_recipe(args):
         reader = RecipeReader(parent_dir, rel_path)
         recipe = reader.read()
     except Exception as e:
-        print("Recipe '%s' is not valid: %s" % (real_path, e))
+        print(("Recipe '%s' is not valid: %s" % (real_path, e)))
         return 1
     try:
         script = recipe_to_bash(recipe,
@@ -165,7 +165,7 @@ def convert_recipe(args):
         else:
             print(script)
     except Exception as e:
-        print("Failed to convert recipe: %s" % e)
+        print(("Failed to convert recipe: %s" % e))
         return 1
 
 if __name__ == "__main__":

--- a/ci/recipe/tests/RecipeTester.py
+++ b/ci/recipe/tests/RecipeTester.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci.tests import utils as test_utils
 from ci.tests import DBTester
 import os, subprocess

--- a/ci/recipe/tests/test_RecipeCreator.py
+++ b/ci/recipe/tests/test_RecipeCreator.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from . import RecipeTester
 from ci.tests import utils as test_utils
 from ci import models

--- a/ci/recipe/tests/test_RecipeCreator.py
+++ b/ci/recipe/tests/test_RecipeCreator.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import RecipeTester
+from . import RecipeTester
 from ci.tests import utils as test_utils
 from ci import models
 from mock import patch

--- a/ci/recipe/tests/test_RecipeReader.py
+++ b/ci/recipe/tests/test_RecipeReader.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci.recipe.RecipeReader import RecipeReader
 from . import RecipeTester
 from ci.tests import utils
@@ -241,3 +242,8 @@ class Tests(RecipeTester.RecipeTester):
             self.assertNotEqual(reader.read(), {})
             reader.config.set("Main", "name", "")
             self.assertEqual(reader.read(), {})
+
+    def test_no_file(self):
+        with utils.RecipeDir() as recipes_dir:
+            with self.assertRaises(Exception):
+                RecipeReader(recipes_dir, "no_exist")

--- a/ci/recipe/tests/test_RecipeReader.py
+++ b/ci/recipe/tests/test_RecipeReader.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from ci.recipe.RecipeReader import RecipeReader
-import RecipeTester
+from . import RecipeTester
 from ci.tests import utils
 
 class Tests(RecipeTester.RecipeTester):
@@ -55,7 +55,7 @@ class Tests(RecipeTester.RecipeTester):
             self.assertEqual(r.get("allow_on_pr"), False)
 
             global_env = r.get("global_env")
-            self.assertEqual(len(global_env.keys()), 2)
+            self.assertEqual(len(list(global_env.keys())), 2)
             self.assertEqual(global_env.get("APPLICATION_NAME"), "civet")
             self.assertEqual(global_env.get("MOOSE_DIR"), "BUILD_ROOT/moose")
 
@@ -80,14 +80,14 @@ class Tests(RecipeTester.RecipeTester):
             self.assertEqual(steps[0].get("script"), "scripts/1.sh")
             self.assertEqual(steps[0].get("abort_on_failure"), True)
             self.assertEqual(steps[0].get("allowed_to_fail"), True)
-            self.assertEqual(len(steps[0].get("environment").keys()), 4)
+            self.assertEqual(len(list(steps[0].get("environment").keys())), 4)
             self.assertEqual(steps[0].get("environment").get("FOO"), "bar")
 
             self.assertEqual(steps[1].get("name"), "Next Step")
             self.assertEqual(steps[1].get("script"), "scripts/2.sh")
             self.assertEqual(steps[1].get("abort_on_failure"), False)
             self.assertEqual(steps[1].get("allowed_to_fail"), False)
-            self.assertEqual(len(steps[1].get("environment").keys()), 4)
+            self.assertEqual(len(list(steps[1].get("environment").keys())), 4)
             self.assertEqual(steps[1].get("environment").get("ENV"), "some string")
 
     def test_check(self):

--- a/ci/recipe/tests/test_RecipeRepoReader.py
+++ b/ci/recipe/tests/test_RecipeRepoReader.py
@@ -16,7 +16,7 @@
 from ci.recipe import RecipeWriter
 from ci.recipe import RecipeRepoReader
 from ci.tests import utils
-import RecipeTester
+from . import RecipeTester
 
 class Tests(RecipeTester.RecipeTester):
     def test_reader(self):

--- a/ci/recipe/tests/test_RecipeRepoReader.py
+++ b/ci/recipe/tests/test_RecipeRepoReader.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci.recipe import RecipeWriter
 from ci.recipe import RecipeRepoReader
 from ci.tests import utils

--- a/ci/recipe/tests/test_RecipeWriter.py
+++ b/ci/recipe/tests/test_RecipeWriter.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci.recipe.RecipeReader import RecipeReader
 from ci.recipe import RecipeWriter
 from ci.tests import utils

--- a/ci/recipe/tests/test_RecipeWriter.py
+++ b/ci/recipe/tests/test_RecipeWriter.py
@@ -16,7 +16,7 @@
 from ci.recipe.RecipeReader import RecipeReader
 from ci.recipe import RecipeWriter
 from ci.tests import utils
-import RecipeTester
+from . import RecipeTester
 
 class Tests(RecipeTester.RecipeTester):
     def test_write(self):
@@ -32,7 +32,7 @@ class Tests(RecipeTester.RecipeTester):
             r["repository"] = "new_repo"
 
             global_env = r.get("global_env")
-            self.assertEqual(len(global_env.keys()), 2)
+            self.assertEqual(len(list(global_env.keys())), 2)
             r["global_env"]["APPLICATION_NAME"] = "new_app"
 
             global_sources = r.get("global_sources")

--- a/ci/recipe/tests/test_file_utils.py
+++ b/ci/recipe/tests/test_file_utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci.recipe import file_utils
 from . import RecipeTester
 from ci.tests import utils

--- a/ci/recipe/tests/test_file_utils.py
+++ b/ci/recipe/tests/test_file_utils.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from ci.recipe import file_utils
-import RecipeTester
+from . import RecipeTester
 from ci.tests import utils
 import os
 

--- a/ci/templatetags/range.py
+++ b/ci/templatetags/range.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.template import Library
 
 register = Library()
@@ -36,4 +37,4 @@ def get_range( value ):
 
       Instead of 3 one may use the variable set in the views
     """
-    return list(range( value))
+    return list(range(value))

--- a/ci/templatetags/range.py
+++ b/ci/templatetags/range.py
@@ -36,4 +36,4 @@ def get_range( value ):
 
       Instead of 3 one may use the variable set in the views
     """
-    return range( value )
+    return list(range( value))

--- a/ci/templatetags/settings_export.py
+++ b/ci/templatetags/settings_export.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django import template
 from django.conf import settings
 from django.urls import reverse

--- a/ci/tests/DBTester.py
+++ b/ci/tests/DBTester.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import TestCase, Client
 from django.conf import settings
 from ci import models

--- a/ci/tests/DBTester.py
+++ b/ci/tests/DBTester.py
@@ -16,7 +16,7 @@
 from django.test import TestCase, Client
 from django.conf import settings
 from ci import models
-import utils
+from . import utils
 from django.test.client import RequestFactory
 
 class DBCompare(object):

--- a/ci/tests/SeleniumTester.py
+++ b/ci/tests/SeleniumTester.py
@@ -233,7 +233,7 @@ class SeleniumTester(StaticLiveServerTestCase):
         ev_html = ev_status.get_attribute('innerHTML')
         self.assertIn(str(ev.base.branch.repository.name), ev_html)
         if ev.pull_request:
-            self.assertIn(escape(unicode(ev.pull_request)), ev_html)
+            self.assertIn(escape(str(ev.pull_request)), ev_html)
         else:
             self.assertIn(str(ev.cause_str), ev_html)
 

--- a/ci/tests/SeleniumTester.py
+++ b/ci/tests/SeleniumTester.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import override_settings
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from selenium import webdriver

--- a/ci/tests/test_DebugViews.py
+++ b/ci/tests/test_DebugViews.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.urls import reverse
 from django.test import override_settings
 from mock import patch
@@ -96,4 +97,4 @@ class Tests(DBTester.DBTester):
             utils.simulate_login(self.client.session, user)
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
-            self.assertIn(job.recipe.name, response.content)
+            self.assertContains(response, job.recipe.name)

--- a/ci/tests/test_DebugViews.py
+++ b/ci/tests/test_DebugViews.py
@@ -18,7 +18,7 @@ from django.test import override_settings
 from mock import patch
 from . import utils
 from ci.github import api
-import DBTester
+from . import DBTester
 
 @override_settings(INSTALLED_GITSERVERS=[utils.github_config()])
 class Tests(DBTester.DBTester):

--- a/ci/tests/test_EventsStatus.py
+++ b/ci/tests/test_EventsStatus.py
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import DBTester
-import utils
+from . import DBTester
+from . import utils
 import datetime
 from ci import EventsStatus, models
 

--- a/ci/tests/test_EventsStatus.py
+++ b/ci/tests/test_EventsStatus.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from . import DBTester
 from . import utils
 import datetime
@@ -79,14 +80,14 @@ class Tests(DBTester.DBTester):
     def test_all_events_info(self):
         self.create_events()
 
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             info = EventsStatus.all_events_info()
             self.assertEqual(len(info), 3)
             # pre, blank, test, test1, blank, merge
             self.assertEqual(len(info[0]["jobs"]), 6)
 
         # make sure limit works
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             info = EventsStatus.all_events_info(limit=1)
             self.assertEqual(len(info), 1)
             self.assertEqual(len(info[0]["jobs"]), 6)
@@ -95,7 +96,7 @@ class Tests(DBTester.DBTester):
         last_modified = last_modified + datetime.timedelta(0,10)
 
         # make sure last_modified works
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             info = EventsStatus.all_events_info(last_modified=last_modified)
             self.assertEqual(len(info), 0)
 

--- a/ci/tests/test_GitCommitData.py
+++ b/ci/tests/test_GitCommitData.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 from ci import models, GitCommitData
-import DBTester
-import utils
+from . import DBTester
+from . import utils
 
 class Tests(DBTester.DBTester):
     def test_create(self):

--- a/ci/tests/test_GitCommitData.py
+++ b/ci/tests/test_GitCommitData.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci import models, GitCommitData
 from . import DBTester
 from . import utils

--- a/ci/tests/test_ManualEvent.py
+++ b/ci/tests/test_ManualEvent.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 from ci import models, ManualEvent
-import DBTester
-import utils
+from . import DBTester
+from . import utils
 
 class Tests(DBTester.DBTester):
     def setUp(self):

--- a/ci/tests/test_ManualEvent.py
+++ b/ci/tests/test_ManualEvent.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci import models, ManualEvent
 from . import DBTester
 from . import utils

--- a/ci/tests/test_Permissions.py
+++ b/ci/tests/test_Permissions.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from mock import patch
 from ci import models, Permissions
 from django.test import override_settings

--- a/ci/tests/test_PullRequestEvent.py
+++ b/ci/tests/test_PullRequestEvent.py
@@ -17,8 +17,8 @@ from ci import models, PullRequestEvent, GitCommitData
 from django.test import override_settings
 from ci.github import api
 from mock import patch
-import DBTester
-import utils
+from . import DBTester
+from . import utils
 
 @override_settings(INSTALLED_GITSERVERS=[utils.github_config()])
 class Tests(DBTester.DBTester):

--- a/ci/tests/test_PullRequestEvent.py
+++ b/ci/tests/test_PullRequestEvent.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci import models, PullRequestEvent, GitCommitData
 from django.test import override_settings
 from ci.github import api

--- a/ci/tests/test_PushEvent.py
+++ b/ci/tests/test_PushEvent.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci import models, PushEvent, GitCommitData
 from . import DBTester
 from . import utils

--- a/ci/tests/test_PushEvent.py
+++ b/ci/tests/test_PushEvent.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 from ci import models, PushEvent, GitCommitData
-import DBTester
-import utils
+from . import DBTester
+from . import utils
 
 class Tests(DBTester.DBTester):
     def setUp(self):

--- a/ci/tests/test_RepositoryStatus.py
+++ b/ci/tests/test_RepositoryStatus.py
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import DBTester
-import utils
+from . import DBTester
+from . import utils
 import datetime
 from ci import RepositoryStatus, models
 

--- a/ci/tests/test_RepositoryStatus.py
+++ b/ci/tests/test_RepositoryStatus.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from . import DBTester
 from . import utils
 import datetime

--- a/ci/tests/test_Stats.py
+++ b/ci/tests/test_Stats.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from . import DBTester
 from ci.tests import utils
 from django.urls import reverse

--- a/ci/tests/test_Stats.py
+++ b/ci/tests/test_Stats.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import DBTester
+from . import DBTester
 from ci.tests import utils
 from django.urls import reverse
 from ci import Stats, TimeUtils

--- a/ci/tests/test_TimeUtils.py
+++ b/ci/tests/test_TimeUtils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from . import DBTester
 from ci import TimeUtils
 import datetime

--- a/ci/tests/test_TimeUtils.py
+++ b/ci/tests/test_TimeUtils.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import DBTester
+from . import DBTester
 from ci import TimeUtils
 import datetime
 

--- a/ci/tests/test_commands.py
+++ b/ci/tests/test_commands.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.core import management
 from django.core.management.base import CommandError
 from django.utils.six import StringIO

--- a/ci/tests/test_commands.py
+++ b/ci/tests/test_commands.py
@@ -19,7 +19,7 @@ from django.test import override_settings
 from mock import patch
 from ci import models
 from . import utils
-import DBTester
+from . import DBTester
 import json
 from requests_oauthlib import OAuth2Session
 

--- a/ci/tests/test_event.py
+++ b/ci/tests/test_event.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci import models, event
 from . import DBTester
 from . import utils

--- a/ci/tests/test_event.py
+++ b/ci/tests/test_event.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 from ci import models, event
-import DBTester
-import utils
+from . import DBTester
+from . import utils
 
 class Tests(DBTester.DBTester):
     def setUp(self):

--- a/ci/tests/test_event_view_selenium.py
+++ b/ci/tests/test_event_view_selenium.py
@@ -13,13 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import SeleniumTester
+from . import SeleniumTester
 from django.test import override_settings
 from ci import models
 from ci import Permissions
 from mock import patch
 from django.urls import reverse
-import utils
+from . import utils
 
 @override_settings(INSTALLED_GITSERVERS=[utils.github_config()])
 class Tests(SeleniumTester.SeleniumTester):

--- a/ci/tests/test_event_view_selenium.py
+++ b/ci/tests/test_event_view_selenium.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from . import SeleniumTester
 from django.test import override_settings
 from ci import models

--- a/ci/tests/test_git_api.py
+++ b/ci/tests/test_git_api.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import override_settings
 from ci.git_api import GitAPI
 from ci.tests import utils

--- a/ci/tests/test_html_validate.py
+++ b/ci/tests/test_html_validate.py
@@ -18,7 +18,7 @@ from django.test.client import RequestFactory
 from py_w3c.validators.html.validator import HTMLValidator
 from django.urls import reverse
 import json
-import utils
+from . import utils
 from ci import models
 import unittest, os
 
@@ -62,11 +62,11 @@ class Tests(TestCase):
         vld = HTMLValidator()
         vld.validate_fragment(response.content)
         if vld.errors or vld.warnings:
-            print(response.content)
+            print((response.content))
         if vld.errors:
-            print("ERRORS: %s" % json.dumps(vld.errors, indent=4))
+            print(("ERRORS: %s" % json.dumps(vld.errors, indent=4)))
         if vld.warnings:
-            print("WARNINGS: %s" % json.dumps(vld.warnings, indent=4))
+            print(("WARNINGS: %s" % json.dumps(vld.warnings, indent=4)))
         self.assertEqual(vld.errors, [])
         self.assertEqual(vld.warnings, [])
 

--- a/ci/tests/test_html_validate.py
+++ b/ci/tests/test_html_validate.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import TestCase, Client
 from django.test.client import RequestFactory
 from py_w3c.validators.html.validator import HTMLValidator
@@ -62,11 +63,11 @@ class Tests(TestCase):
         vld = HTMLValidator()
         vld.validate_fragment(response.content)
         if vld.errors or vld.warnings:
-            print((response.content))
+            print(response.content)
         if vld.errors:
-            print(("ERRORS: %s" % json.dumps(vld.errors, indent=4)))
+            print("ERRORS: %s" % json.dumps(vld.errors, indent=4))
         if vld.warnings:
-            print(("WARNINGS: %s" % json.dumps(vld.warnings, indent=4)))
+            print("WARNINGS: %s" % json.dumps(vld.warnings, indent=4))
         self.assertEqual(vld.errors, [])
         self.assertEqual(vld.warnings, [])
 

--- a/ci/tests/test_job_view_selenium.py
+++ b/ci/tests/test_job_view_selenium.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from . import SeleniumTester
 from . import utils
 from ci import models

--- a/ci/tests/test_job_view_selenium.py
+++ b/ci/tests/test_job_view_selenium.py
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import SeleniumTester
-import utils
+from . import SeleniumTester
+from . import utils
 from ci import models
 from ci import Permissions
 from ci.client import views as client_views

--- a/ci/tests/test_main_view_selenium.py
+++ b/ci/tests/test_main_view_selenium.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from . import SeleniumTester
 from . import utils
 from ci import models

--- a/ci/tests/test_main_view_selenium.py
+++ b/ci/tests/test_main_view_selenium.py
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import SeleniumTester
-import utils
+from . import SeleniumTester
+from . import utils
 from ci import models
 from django.urls import reverse
 from django.test import override_settings

--- a/ci/tests/test_models.py
+++ b/ci/tests/test_models.py
@@ -270,7 +270,7 @@ class Tests(TestCase):
 
         self.assertEqual(rc.auto_str(), models.Recipe.AUTO_CHOICES[rc.automatic][1])
         self.assertEqual(rc.cause_str(), models.Recipe.CAUSE_CHOICES[rc.cause][1])
-        self.assertTrue(isinstance(rc.configs_str(), basestring))
+        self.assertTrue(isinstance(rc.configs_str(), str))
 
         rc.cause = models.Recipe.CAUSE_PUSH
         rc.branch = utils.create_branch()

--- a/ci/tests/test_models.py
+++ b/ci/tests/test_models.py
@@ -13,12 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import TestCase
 from django.conf import settings
 from django.test import override_settings
 from ci import models
 from . import utils
 import math
+from django.utils import six
 
 @override_settings(INSTALLED_GITSERVERS=[utils.github_config()])
 class Tests(TestCase):
@@ -26,7 +28,7 @@ class Tests(TestCase):
         with self.settings(INSTALLED_GITSERVERS=[utils.github_config(), utils.gitlab_config(hostname="gitlab_server"), utils.bitbucket_config(hostname="bitbucket_server")]):
             server = utils.create_git_server(host_type=settings.GITSERVER_GITHUB)
             self.assertTrue(isinstance(server, models.GitServer))
-            self.assertEqual(server.__unicode__(), server.name)
+            self.assertEqual(server.__str__(), server.name)
             self.assertNotEqual(server.api(), None)
             self.assertNotEqual(server.auth(), None)
             self.assertFalse(server.post_event_summary())
@@ -54,7 +56,7 @@ class Tests(TestCase):
     def test_git_user(self):
         user = utils.create_user()
         self.assertTrue(isinstance(user, models.GitUser))
-        self.assertEqual(user.__unicode__(), user.name)
+        self.assertEqual(user.__str__(), user.name)
         session = user.start_session()
         self.assertNotEqual(session, None)
         self.assertNotEqual(user.api(), None)
@@ -63,8 +65,8 @@ class Tests(TestCase):
     def test_repository(self):
         repo = utils.create_repo()
         self.assertTrue(isinstance(repo, models.Repository))
-        self.assertIn(repo.name, repo.__unicode__())
-        self.assertIn(repo.user.name, repo.__unicode__())
+        self.assertIn(repo.name, repo.__str__())
+        self.assertIn(repo.user.name, repo.__str__())
         url = repo.repo_html_url()
         self.assertIn(repo.user.name, url)
         self.assertIn(repo.name, url)
@@ -72,9 +74,9 @@ class Tests(TestCase):
     def test_branch(self):
         branch = utils.create_branch()
         self.assertTrue(isinstance(branch, models.Branch))
-        self.assertIn(branch.repository.name, branch.__unicode__())
-        self.assertIn(branch.repository.user.name, branch.__unicode__())
-        self.assertIn(branch.name, branch.__unicode__())
+        self.assertIn(branch.repository.name, branch.__str__())
+        self.assertIn(branch.repository.user.name, branch.__str__())
+        self.assertIn(branch.name, branch.__str__())
         server = branch.server()
         self.assertEqual(server, branch.repository.user.server)
         user = branch.user()
@@ -84,8 +86,8 @@ class Tests(TestCase):
     def test_commit(self):
         commit = utils.create_commit()
         self.assertTrue(isinstance(commit, models.Commit))
-        self.assertIn(commit.branch.name, commit.__unicode__())
-        self.assertIn(commit.sha, commit.__unicode__())
+        self.assertIn(commit.branch.name, commit.__str__())
+        self.assertIn(commit.sha, commit.__str__())
         self.assertEqual(commit.server(), commit.branch.repository.user.server)
         self.assertEqual(commit.repo(), commit.branch.repository)
         self.assertNotEqual(commit.commit_html_url(), None)
@@ -174,7 +176,7 @@ class Tests(TestCase):
     def test_event(self):
         event = utils.create_event()
         self.assertTrue(isinstance(event, models.Event))
-        self.assertIn('Pull', event.__unicode__())
+        self.assertIn('Pull', event.__str__())
         self.assertIn('Pull', event.cause_str())
         event.cause = models.Event.PUSH
         event.save()
@@ -214,11 +216,12 @@ class Tests(TestCase):
         j2.recipe.priority = 1
         j2.recipe.display_name = 'r2'
         j2.recipe.save()
-        self.assertEqual(models.sorted_job_compare(j0, j1), 1)
-        self.assertEqual(models.sorted_job_compare(j1, j0), -1)
-        self.assertEqual(models.sorted_job_compare(j0, j2), -1)
-        self.assertEqual(models.sorted_job_compare(j2, j0), 1)
-        self.assertEqual(models.sorted_job_compare(j0, j0), 0)
+        self.assertEqual(models.Event.sorted_jobs([j0, j1]), [j1, j0])
+        self.assertEqual(models.Event.sorted_jobs([j1, j0]), [j1, j0])
+        self.assertEqual(models.Event.sorted_jobs([j0, j2]), [j0, j2])
+        self.assertEqual(models.Event.sorted_jobs([j2, j0]), [j0, j2])
+        self.assertEqual(models.Event.sorted_jobs([j1, j2]), [j1, j2])
+        self.assertEqual(models.Event.sorted_jobs([j2, j1, j0]), [j1, j0, j2])
         job_groups = event.get_sorted_jobs()
         self.assertEqual(len(job_groups), 3)
         self.assertEqual(len(job_groups[0]), 1)
@@ -233,12 +236,12 @@ class Tests(TestCase):
 
         j2.recipe.display_name = 'r0'
         j2.recipe.save()
-        self.assertEqual(models.sorted_job_compare(j2, j0), 0)
-        self.assertEqual(models.sorted_job_compare(j0, j2), 0)
+        self.assertEqual(models.Event.sorted_jobs([j2, j0]), [j0, j2])
+        self.assertEqual(models.Event.sorted_jobs([j0, j2]), [j0, j2])
 
         j2.config = utils.create_build_config("Aconfig")
-        self.assertEqual(models.sorted_job_compare(j2, j0), -1)
-        self.assertEqual(models.sorted_job_compare(j0, j2), 1)
+        self.assertEqual(models.Event.sorted_jobs([j2, j0]), [j2, j0])
+        self.assertEqual(models.Event.sorted_jobs([j0, j2]), [j2, j0])
 
         self.assertEqual(event.get_changed_files(), [])
         changed = ["foo/bar", "bar/foo"]
@@ -255,22 +258,22 @@ class Tests(TestCase):
     def test_pullrequest(self):
         pr = utils.create_pr()
         self.assertTrue(isinstance(pr, models.PullRequest))
-        self.assertIn(pr.title, pr.__unicode__())
+        self.assertIn(pr.title, pr.__str__())
         self.assertNotEqual(pr.status_slug(), None)
 
     def test_buildconfig(self):
         bc = utils.create_build_config()
         self.assertTrue(isinstance(bc, models.BuildConfig))
-        self.assertIn(bc.name, bc.__unicode__())
+        self.assertIn(bc.name, bc.__str__())
 
     def test_recipe(self):
         rc = utils.create_recipe()
         self.assertTrue(isinstance(rc, models.Recipe))
-        self.assertIn(rc.name, rc.__unicode__())
+        self.assertIn(rc.name, rc.__str__())
 
         self.assertEqual(rc.auto_str(), models.Recipe.AUTO_CHOICES[rc.automatic][1])
         self.assertEqual(rc.cause_str(), models.Recipe.CAUSE_CHOICES[rc.cause][1])
-        self.assertTrue(isinstance(rc.configs_str(), str))
+        self.assertTrue(isinstance(rc.configs_str(), six.string_types))
 
         rc.cause = models.Recipe.CAUSE_PUSH
         rc.branch = utils.create_branch()
@@ -286,29 +289,29 @@ class Tests(TestCase):
     def test_recipeenv(self):
         renv = utils.create_recipe_environment()
         self.assertTrue(isinstance(renv, models.RecipeEnvironment))
-        self.assertIn(renv.name, renv.__unicode__())
-        self.assertIn(renv.value, renv.__unicode__())
+        self.assertIn(renv.name, renv.__str__())
+        self.assertIn(renv.value, renv.__str__())
 
     def test_prestepsource(self):
         s = utils.create_prestepsource()
         self.assertTrue(isinstance(s, models.PreStepSource))
-        self.assertIn(s.filename, s.__unicode__())
+        self.assertIn(s.filename, s.__str__())
 
     def test_step(self):
         s = utils.create_step()
         self.assertTrue(isinstance(s, models.Step))
-        self.assertIn(s.name, s.__unicode__())
+        self.assertIn(s.name, s.__str__())
 
     def test_stepenvironment(self):
         se = utils.create_step_environment()
         self.assertTrue(isinstance(se, models.StepEnvironment))
-        self.assertIn(se.name, se.__unicode__())
-        self.assertIn(se.value, se.__unicode__())
+        self.assertIn(se.name, se.__str__())
+        self.assertIn(se.value, se.__str__())
 
     def test_client(self):
         c = utils.create_client()
         self.assertTrue(isinstance(c, models.Client))
-        self.assertIn(c.name, c.__unicode__())
+        self.assertIn(c.name, c.__str__())
         self.assertNotEqual(c.status_str(), '')
         self.assertGreater(c.unseen_seconds(), 0)
 
@@ -317,7 +320,7 @@ class Tests(TestCase):
         j.status = models.JobStatus.NOT_STARTED
         j.save()
         self.assertTrue(isinstance(j, models.Job))
-        self.assertIn(j.recipe.name, j.__unicode__())
+        self.assertIn(j.recipe.name, j.__str__())
         self.assertEqual(None, j.failed_result())
         self.assertEqual(j.status_slug(), 'Not_Started')
         self.assertEqual(j.status_str(), 'Not started')
@@ -448,7 +451,7 @@ class Tests(TestCase):
         sr.output = '&<\n\33[30mfoo\33[0m'
         sr.save()
         self.assertTrue(isinstance(sr, models.StepResult))
-        self.assertIn(sr.name, sr.__unicode__())
+        self.assertIn(sr.name, sr.__str__())
         self.assertEqual(models.JobStatus.to_slug(sr.status), sr.status_slug())
         self.assertEqual(sr.clean_output(), '&amp;&lt;<br/><span class="ansi30">foo</span>')
         self.assertEqual(sr.plain_output(), "&<\nfoo")
@@ -471,12 +474,12 @@ class Tests(TestCase):
 
     def test_osversion(self):
         os, created = models.OSVersion.objects.get_or_create(name="os", version="1")
-        self.assertIn("os", os.__unicode__())
-        self.assertIn("1", os.__unicode__())
+        self.assertIn("os", os.__str__())
+        self.assertIn("1", os.__str__())
 
     def test_loadedmodule(self):
         mod, created = models.LoadedModule.objects.get_or_create(name="module")
-        self.assertIn("module", mod.__unicode__())
+        self.assertIn("module", mod.__str__())
 
     def test_humanize_bytes(self):
         self.assertEqual(models.humanize_bytes(10), "10.0 B")
@@ -486,19 +489,19 @@ class Tests(TestCase):
     def test_jobTestStatistics(self):
         job = utils.create_job()
         stats, created = models.JobTestStatistics.objects.get_or_create(job=job, passed=1, failed=2, skipped=3)
-        s = stats.__unicode__()
+        s = stats.__str__()
         self.assertIn("1 passed", s)
         self.assertIn("2 failed", s)
         self.assertIn("3 skipped", s)
 
     def test_gitevent(self):
         ge = utils.create_git_event()
-        s = ge.__unicode__()
+        s = ge.__str__()
         self.assertIn("Success", s)
         self.assertIn("foo", ge.dump())
         ge.success = False
         ge.body = ""
         ge.save()
-        s = ge.__unicode__()
+        s = ge.__str__()
         self.assertIn("Error", s)
         self.assertEqual("", ge.dump())

--- a/ci/tests/test_oauth_api.py
+++ b/ci/tests/test_oauth_api.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import TestCase, Client
 from django.test import override_settings
 from ci import oauth_api

--- a/ci/tests/test_pr_view_selenium.py
+++ b/ci/tests/test_pr_view_selenium.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from . import SeleniumTester
 from ci import models
 from django.urls import reverse

--- a/ci/tests/test_pr_view_selenium.py
+++ b/ci/tests/test_pr_view_selenium.py
@@ -13,11 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import SeleniumTester
+from . import SeleniumTester
 from ci import models
 from django.urls import reverse
 from django.test import override_settings
-import utils
+from . import utils
 
 @override_settings(INSTALLED_GITSERVERS=[utils.github_config()])
 class Tests(SeleniumTester.SeleniumTester):

--- a/ci/tests/test_repo_view_selenium.py
+++ b/ci/tests/test_repo_view_selenium.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from . import SeleniumTester
 from django.test import override_settings
 from . import utils

--- a/ci/tests/test_repo_view_selenium.py
+++ b/ci/tests/test_repo_view_selenium.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import SeleniumTester
+from . import SeleniumTester
 from django.test import override_settings
-import utils
+from . import utils
 from ci import models
 from django.urls import reverse
 

--- a/ci/tests/test_user_repo_prefs_selenium.py
+++ b/ci/tests/test_user_repo_prefs_selenium.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from . import SeleniumTester
 from . import utils
 from django.urls import reverse

--- a/ci/tests/test_user_repo_prefs_selenium.py
+++ b/ci/tests/test_user_repo_prefs_selenium.py
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import SeleniumTester
-import utils
+from . import SeleniumTester
+from . import utils
 from django.urls import reverse
 from django.test import override_settings
 

--- a/ci/tests/test_views.py
+++ b/ci/tests/test_views.py
@@ -20,7 +20,7 @@ from mock import patch
 from ci import models, views, Permissions, PullRequestEvent, GitCommitData
 from . import utils
 from ci.github import api
-import DBTester
+from . import DBTester
 import datetime
 from requests_oauthlib import OAuth2Session
 
@@ -228,7 +228,7 @@ class Tests(DBTester.DBTester):
         self.assertEqual(objs.paginator.num_pages, 1)
         self.assertEqual(objs.paginator.count, 6)
 
-        for i in xrange(10):
+        for i in range(10):
             utils.create_recipe(name='recipe %s' % i)
 
         # now there are 16 recipes, so page=2 should be

--- a/ci/tests/test_views.py
+++ b/ci/tests/test_views.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.urls import reverse
 from django.test import override_settings
 from django.conf import settings
@@ -36,16 +37,16 @@ class Tests(DBTester.DBTester):
         """
         response = self.client.get(reverse('ci:main'))
         self.assertEqual(response.status_code, 200)
-        self.assertIn('Sign in', response.content)
-        self.assertNotIn('Sign out', response.content)
+        self.assertContains(response, 'Sign in')
+        self.assertNotContains(response, 'Sign out')
 
         user = utils.get_test_user()
         utils.simulate_login(self.client.session, user)
         auth = user.auth()
         self.assertIn(auth._user_key, self.client.session)
         response = self.client.get(reverse('ci:main'))
-        self.assertIn('Sign out', response.content)
-        self.assertNotIn('Sign in', response.content)
+        self.assertContains(response, 'Sign out')
+        self.assertNotContains(response, 'Sign in')
 
     @patch.object(api.GitHubAPI, 'is_collaborator')
     @override_settings(COLLABORATOR_CACHE_TIMEOUT=0)
@@ -296,24 +297,24 @@ class Tests(DBTester.DBTester):
             url = reverse('ci:view_client', args=[client.pk,])
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
-            self.assertIn("You are not allowed", response.content)
+            self.assertContains(response, "You are not allowed")
 
             # logged in but not on the authorized list
             utils.simulate_login(self.client.session, user)
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
-            self.assertIn("You are not allowed", response.content)
+            self.assertContains(response, "You are not allowed")
 
         with self.settings(INSTALLED_GITSERVERS=[utils.github_config(authorized_users=[user.name])]):
             # logged in and on the authorized list
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
-            self.assertNotIn("You are not allowed", response.content)
+            self.assertNotContains(response, "You are not allowed")
 
             # Should be cached
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
-            self.assertNotIn("You are not allowed", response.content)
+            self.assertNotContains(response, "You are not allowed")
 
     def test_view_branch(self):
         response = self.client.get(reverse('ci:view_branch', args=[1000,]))
@@ -359,7 +360,7 @@ class Tests(DBTester.DBTester):
         response = self.client.get(reverse('ci:client_list'))
         self.assertEqual(response.status_code, 200)
         for c in models.Client.objects.all():
-            self.assertNotIn(c.name, response.content)
+            self.assertNotContains(response, c.name)
 
         # allowed
         mock_allowed.return_value = True
@@ -367,8 +368,8 @@ class Tests(DBTester.DBTester):
         self.assertEqual(response.status_code, 200)
         for i in range(10):
             name = "client%s" % i
-            self.assertIn(name, response.content)
-            self.assertIn('status_%i" class="client_Running"' % (i+1), response.content)
+            self.assertContains(response, name)
+            self.assertContains(response, 'status_%i" class="client_Running"' % (i+1))
 
         inactive = []
         for i in range(5):
@@ -381,11 +382,11 @@ class Tests(DBTester.DBTester):
         self.assertEqual(response.status_code, 200)
         for i in range(10):
             name = "client%s" % i
-            self.assertIn(name, response.content)
+            self.assertContains(response, name)
             if name in inactive:
-                self.assertIn('status_%i" class="client_NotSeen"' % (i+1), response.content)
+                self.assertContains(response, 'status_%i" class="client_NotSeen"' % (i+1))
             else:
-                self.assertIn('status_%i" class="client_Running"' % (i+1), response.content)
+                self.assertContains(response, 'status_%i" class="client_Running"' % (i+1))
 
         for name in inactive:
             c = models.Client.objects.get(name=name)
@@ -395,10 +396,10 @@ class Tests(DBTester.DBTester):
         self.assertEqual(response.status_code, 200)
         for c in models.Client.objects.all():
             if c.name in inactive:
-                self.assertNotIn(c.name, response.content)
+                self.assertNotContains(response, c.name)
                 self.assertEqual(c.status, models.Client.DOWN)
             else:
-                self.assertIn(c.name, response.content)
+                self.assertContains(response, c.name)
 
     def test_event_list(self):
         response = self.client.get(reverse('ci:event_list'))
@@ -876,7 +877,7 @@ class Tests(DBTester.DBTester):
         self.set_counts()
         response = self.client.post(url)
         self.assertEqual(response.status_code, 200)
-        self.assertIn('Success', response.content)
+        self.assertContains(response, 'Success')
         self.compare_counts(num_git_events=1)
 
         # branch exists, jobs will get created
@@ -884,7 +885,7 @@ class Tests(DBTester.DBTester):
         self.set_counts()
         response = self.client.post(url)
         self.assertEqual(response.status_code, 200)
-        self.assertIn('Success', response.content)
+        self.assertContains(response, 'Success')
         self.compare_counts(jobs=1, events=1, ready=1, commits=1, active=1, active_repos=1, num_git_events=1)
         ev = models.Event.objects.first()
         self.assertTrue(ev.update_branch_status)
@@ -925,7 +926,7 @@ class Tests(DBTester.DBTester):
         response = self.client.post(url)
         self.compare_counts(num_git_events=1)
         self.assertEqual(response.status_code, 200)
-        self.assertIn('Error', response.content)
+        self.assertContains(response, 'Error')
 
     def test_get_job_results(self):
         # bad pk
@@ -1060,7 +1061,7 @@ class Tests(DBTester.DBTester):
         response = self.client.get(url)
         self.compare_counts()
         self.assertEqual(response.status_code, 200)
-        self.assertNotIn("form", response.content)
+        self.assertNotContains(response, "form")
 
         user = repos[0].user
         utils.simulate_login(self.client.session, user)
@@ -1068,7 +1069,7 @@ class Tests(DBTester.DBTester):
         response = self.client.get(url)
         self.compare_counts()
         self.assertEqual(response.status_code, 200)
-        self.assertIn("form", response.content)
+        self.assertContains(response, "form")
 
         # post an invalid form
         self.set_counts()
@@ -1147,21 +1148,21 @@ class Tests(DBTester.DBTester):
         # no events
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertIn("not initiated", response.content)
+        self.assertContains(response, "not initiated")
 
         # not signed in
         ge = utils.create_git_event()
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertIn("not initiated", response.content)
+        self.assertContains(response, "not initiated")
 
         utils.simulate_login(self.client.session, ge.user)
 
         # OK
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertNotIn("not initiated", response.content)
-        self.assertNotIn("Retry", response.content)
+        self.assertNotContains(response, "not initiated")
+        self.assertNotContains(response, "Retry")
 
         ge.response = "BAD!"
         ge.processed(success=False)
@@ -1169,7 +1170,7 @@ class Tests(DBTester.DBTester):
         # A Failed event
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertIn("Retry", response.content)
+        self.assertContains(response, "Retry")
 
     def test_retry_git_event(self):
         # only POST allowed

--- a/ci/tests/utils.py
+++ b/ci/tests/utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.conf import settings
 from django.test import override_settings
 from ci import models

--- a/ci/urls.py
+++ b/ci/urls.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.conf.urls import url, include
 from django.http import HttpResponse
 from . import views, DebugViews, Stats

--- a/ci/views.py
+++ b/ci/views.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.shortcuts import render, redirect, get_object_or_404
 from django.views.decorators.csrf import csrf_exempt
 from django.http import HttpResponse, HttpResponseNotAllowed, HttpResponseForbidden, Http404
@@ -72,7 +73,7 @@ def get_user_repos_info(request, limit=30, last_modified=None):
 
 def sorted_clients(client_q):
     clients = [ c for c in client_q.all() ]
-    clients.sort(key=lambda s: [int(t) if t.isdigit() else t.lower() for t in re.split('(\d+)', s.name)])
+    clients.sort(key=lambda s: [int(t) if t.isdigit() else t.lower() for t in re.split(r'(\d+)', s.name)])
     return clients
 
 def main(request):
@@ -130,7 +131,7 @@ def user_repo_settings(request):
         form = forms.UserRepositorySettingsForm(request.POST)
         form.fields["repositories"].choices = all_repos
         if form.is_valid():
-            for server, user in list(users.items()):
+            for server, user in users.items():
                 messages.info(request, "Set repository preferences for %s" % user)
                 user.preferred_repos.clear()
 
@@ -206,7 +207,7 @@ def view_pr(request, pr_id):
             else:
                 messages.warning(request, "Invalid form")
                 logger.warning("Invalid form")
-                for field, errors in list(form.errors.items()):
+                for field, errors in form.errors.items():
                     logger.warning("Form error in field: %s: %s" % (field, errors))
 
     events = EventsStatus.events_with_head(pr.events)
@@ -252,7 +253,8 @@ def get_job_results(request, job_id):
     for result in job.step_results.all():
         info = tarfile.TarInfo(name='{}/{:02}_{}'.format(base_name, result.position, result.name))
         s = io.StringIO(result.plain_output().replace('\u2018', "'").replace("\u2019", "'"))
-        info.size = len(s.buf)
+        buf = s.getvalue()
+        info.size = len(buf)
         info.mtime = time.time()
         tar.addfile(tarinfo=info, fileobj=s)
     tar.close()

--- a/client/BaseClient.py
+++ b/client/BaseClient.py
@@ -14,10 +14,10 @@
 # limitations under the License.
 
 import logging, logging.handlers
-from JobGetter import JobGetter
-from JobRunner import JobRunner
-from ServerUpdater import ServerUpdater
-from InterruptHandler import InterruptHandler
+from .JobGetter import JobGetter
+from .JobRunner import JobRunner
+from .ServerUpdater import ServerUpdater
+from .InterruptHandler import InterruptHandler
 import os, signal
 import time
 import traceback
@@ -26,7 +26,7 @@ import logging
 logger = logging.getLogger("civet_client")
 
 from threading import Thread
-from Queue import Queue
+from queue import Queue
 
 def has_handler(handler_type):
     """

--- a/client/BaseClient.py
+++ b/client/BaseClient.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import logging, logging.handlers
 from .JobGetter import JobGetter
 from .JobRunner import JobRunner
@@ -186,8 +187,8 @@ class BaseClient(object):
                     self.run_claimed_job(server, [server], claimed)
                     # finished the job, look for a new one immediately
                     do_poll = False
-            except Exception as e:
-                logger.warning("Error: %s" % traceback.format_exc(e))
+            except Exception:
+                logger.warning("Error: %s" % traceback.format_exc())
 
             if self.cancel_signal.triggered or self.graceful_signal.triggered:
                 logger.info("Received signal...exiting")

--- a/client/INLClient.py
+++ b/client/INLClient.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from . import BaseClient
 import os
 import time, traceback
@@ -89,7 +90,7 @@ class INLClient(BaseClient.BaseClient):
         Returns:
           None
         """
-        for k, v in list(settings.ENVIRONMENT.items()):
+        for k, v in settings.ENVIRONMENT.items():
             os.environ[str(k)] = str(v)
 
         logger.info('Starting {} with MOOSE_JOBS={}'.format(self.client_info["client_name"], os.environ['MOOSE_JOBS']))
@@ -108,8 +109,8 @@ class INLClient(BaseClient.BaseClient):
                 try:
                     if self.check_server(server):
                         ran_job = True
-                except Exception as e:
-                    logger.debug("Error: %s" % traceback.format_exc(e))
+                except Exception:
+                    logger.debug("Error: %s" % traceback.format_exc())
                     break
 
             if self.cancel_signal.triggered or self.graceful_signal.triggered:

--- a/client/INLClient.py
+++ b/client/INLClient.py
@@ -13,12 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import BaseClient
+from . import BaseClient
 import os
 import time, traceback
-from JobGetter import JobGetter
-import settings
-import Modules
+from .JobGetter import JobGetter
+from . import settings
+from . import Modules
 import logging
 logger = logging.getLogger("civet_client")
 
@@ -89,12 +89,12 @@ class INLClient(BaseClient.BaseClient):
         Returns:
           None
         """
-        for k, v in settings.ENVIRONMENT.items():
+        for k, v in list(settings.ENVIRONMENT.items()):
             os.environ[str(k)] = str(v)
 
         logger.info('Starting {} with MOOSE_JOBS={}'.format(self.client_info["client_name"], os.environ['MOOSE_JOBS']))
         logger.info('Build root: {}'.format(os.environ['BUILD_ROOT']))
-        self.client_info["build_configs"] = settings.CONFIG_MODULES.keys()
+        self.client_info["build_configs"] = list(settings.CONFIG_MODULES.keys())
 
         # Do a clear_and_load here in case there is a problem with the module system.
         # We don't want to run if we can't do modules.

--- a/client/InterruptHandler.py
+++ b/client/InterruptHandler.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import signal
 
 class InterruptHandler(object):

--- a/client/JobGetter.py
+++ b/client/JobGetter.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import requests
 import traceback
 import json
@@ -127,8 +128,8 @@ class JobGetter(object):
                     return claim
                 else:
                     logger.info("Failed to claim job %s. Response: %s" % (job['id'], claim))
-            except Exception as e:
-                logger.warning('Tried and failed to claim job %s. Error: %s' % (job['id'], traceback.format_exc(e)))
+            except Exception:
+                logger.warning('Tried and failed to claim job %s. Error: %s' % (job['id'], traceback.format_exc()))
 
         logger.info('No jobs to run')
         return None

--- a/client/JobRunner.py
+++ b/client/JobRunner.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import os, re, time
 import tempfile
 import subprocess, platform
@@ -98,7 +99,7 @@ class JobRunner(object):
                 d[str(t[0])] = str(t[1])
             return d
         elif isinstance(env, dict):
-            return {str(k): str(v) for k, v in list(env.items())}
+            return {str(k): str(v) for k, v in env.items()}
         return {}
 
     def run_job(self):
@@ -266,7 +267,7 @@ class JobRunner(object):
             for line in iter(out.readline, b''):
                 if line:
                     # Make sure it doesn't have any bad unicode characters
-                    line = line.decode("utf-8", "replace").encode("utf-8", "replace")
+                    line = line.decode("utf-8", "replace")
                 queue.put(line)
             out.close()
 
@@ -350,6 +351,12 @@ class JobRunner(object):
             if proc.poll() is None:
                 logger.warning("Trying to forcefully kill %s" % proc.pid)
                 proc.kill()
+
+            # We can sometimes get a warning if these aren't closed
+            if proc.stdout:
+                proc.stdout.close()
+            if proc.stderr:
+                proc.stderr.close()
 
             if proc.poll() is None:
                 logger.warning("Unable to kill process %s." % proc.pid)
@@ -442,14 +449,14 @@ class JobRunner(object):
         Return:
           dict: An updated version of step_data
         """
+        proc = None
         try:
             with temp_file() as step_script:
-                step_script.write(self.all_sources)
-                step_script.write('\n%s\n' % step['script'])
+                step_script.write(self.all_sources.encode("utf-8"))
+                step_script.write('\n{}\n'.format(step['script']).encode())
                 step_script.flush()
                 step_script.close()
                 with open(os.devnull, "wb") as devnull:
-                    proc = None
                     try:
                         proc = self.create_process(step_script.name, step_env, devnull)
                     except Exception as e:
@@ -465,6 +472,8 @@ class JobRunner(object):
             # The main error that we are trying to catch is IOError (out of disk space)
             # but there might be others
             err_str = "Error running step: %s" % e
+            if proc and proc.poll() is None:
+                self.kill_job(proc)
             logger.warning(err_str)
             self.error = True
             step_data["output"] = err_str

--- a/client/JobRunner.py
+++ b/client/JobRunner.py
@@ -21,7 +21,7 @@ import contextlib
 import signal
 logger = logging.getLogger("civet_client")
 
-from Queue import Queue, Empty
+from queue import Queue, Empty
 from threading import Thread
 
 @contextlib.contextmanager
@@ -64,7 +64,7 @@ class JobRunner(object):
         self.error = False
         self.max_output_size = client_info.get("max_output_size", 5*1024*1024) # Stop collecting after 5Mb
         # Windows Python hates unicode in environment strings!
-        self.global_env = {str(key): str(value) for key, value in os.environ.iteritems()}
+        self.global_env = {str(key): str(value) for key, value in os.environ.items()}
         # For backwards compatability
         env_dict = self.env_to_dict(self.job_data.get("environment", {}))
         self.global_env.update(env_dict)
@@ -98,7 +98,7 @@ class JobRunner(object):
                 d[str(t[0])] = str(t[1])
             return d
         elif isinstance(env, dict):
-            return {str(k): str(v) for k, v in env.items()}
+            return {str(k): str(v) for k, v in list(env.items())}
         return {}
 
     def run_job(self):
@@ -336,7 +336,7 @@ class JobRunner(object):
           proc: subprocess.Popen instance
         """
         try:
-            for i in xrange(5): # just try a few times to absolutely kill it
+            for i in range(5): # just try a few times to absolutely kill it
                 if self.is_windows():
                     proc.terminate()
                 else:
@@ -540,7 +540,7 @@ class JobRunner(object):
         Input:
           dict: environment variables
         """
-        for key, value in env.iteritems():
+        for key, value in env.items():
             env[str(key)] = str(self.replace_environment(str(value)))
 
     def replace_environment(self, env_value):

--- a/client/Modules.py
+++ b/client/Modules.py
@@ -29,7 +29,7 @@ class Modules(object):
           Exception: If we don't have a good modules environmnet.
         """
         super(Modules, self).__init__()
-        if not os.environ.has_key("MODULESHOME"):
+        if "MODULESHOME" not in os.environ:
             raise Exception("No module environment detected")
 
     def is_exe(self, path):
@@ -60,7 +60,7 @@ class Modules(object):
         (output, error) = proc.communicate()
         if proc.returncode == 0:
             try:
-                exec output
+                exec(output)
             except Exception as e:
                 full_cmd = [command] + args
                 return {"success": False,

--- a/client/Modules.py
+++ b/client/Modules.py
@@ -1,4 +1,3 @@
-
 # Copyright 2016 Battelle Energy Alliance, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import os, subprocess
 
 class Modules(object):
@@ -58,6 +58,8 @@ class Modules(object):
 
         proc = subprocess.Popen([module_cmd, 'python', command] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (output, error) = proc.communicate()
+        output = output.decode("utf-8")
+        error = error.decode("utf-8")
         if proc.returncode == 0:
             try:
                 exec(output)

--- a/client/ServerUpdater.py
+++ b/client/ServerUpdater.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import sys
 import time
 import json, requests
@@ -185,7 +186,7 @@ class ServerUpdater(object):
         If we have recently contacted the server
         then we don't need to contact them again.
         """
-        for server, data in list(self.servers.items()):
+        for server, data in self.servers.items():
             current_time = time.time()
             diff = current_time - data["last_time"]
             if diff >= self.client_info["server_update_interval"]:
@@ -210,14 +211,10 @@ class ServerUpdater(object):
           tuple(dict/json, bool): The serialized JSON. The bool indicates whether it was successful
         """
         try:
-            # Get rid of any possible bad characters
-            for k in list(data.keys()):
-                if isinstance(data[k], str):
-                    data[k] = data[k].decode("utf-8", "replace").encode("utf-8", "replace")
             in_json = json.dumps(data, separators=(",", ": "))
             return in_json, True
         except Exception as e:
-            logger.warning("Failed to convert to json: %s\n%s\nData:%s" % (e, traceback.format_exc(e), data))
+            logger.warning("Failed to convert to json: %s\n%s\nData:\n%s" % (e, traceback.format_exc(), data))
             return {"status": "OK", "command": "stop"}, False
 
     def post_json(self, request_url, data):
@@ -254,5 +251,5 @@ class ServerUpdater(object):
             reply = response.json()
             return reply
         except Exception as e:
-            logger.warning("Failed to POST at {}.\nMessage: {}\nError: {}".format(request_url, e, traceback.format_exc(e)))
+            logger.warning("Failed to POST at {}.\nMessage: {}\nError: {}".format(request_url, e, traceback.format_exc()))
             return None

--- a/client/ServerUpdater.py
+++ b/client/ServerUpdater.py
@@ -18,7 +18,7 @@ import time
 import json, requests
 import traceback
 import logging
-from Queue import Empty
+from queue import Empty
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
@@ -185,7 +185,7 @@ class ServerUpdater(object):
         If we have recently contacted the server
         then we don't need to contact them again.
         """
-        for server, data in self.servers.items():
+        for server, data in list(self.servers.items()):
             current_time = time.time()
             diff = current_time - data["last_time"]
             if diff >= self.client_info["server_update_interval"]:
@@ -211,7 +211,7 @@ class ServerUpdater(object):
         """
         try:
             # Get rid of any possible bad characters
-            for k in data.keys():
+            for k in list(data.keys()):
                 if isinstance(data[k], str):
                     data[k] = data[k].decode("utf-8", "replace").encode("utf-8", "replace")
             in_json = json.dumps(data, separators=(",", ": "))

--- a/client/client.py
+++ b/client/client.py
@@ -16,7 +16,7 @@
 
 import argparse
 import sys, os
-import BaseClient
+from . import BaseClient
 from DaemonLite import DaemonLite
 
 class ClientDaemon(DaemonLite):

--- a/client/client.py
+++ b/client/client.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import argparse
 import sys, os
 from . import BaseClient

--- a/client/inl_client.py
+++ b/client/inl_client.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import os, sys, argparse
 import socket
 from . import INLClient

--- a/client/inl_client.py
+++ b/client/inl_client.py
@@ -16,7 +16,7 @@
 
 import os, sys, argparse
 import socket
-import INLClient
+from . import INLClient
 from DaemonLite import DaemonLite
 
 def commandline_client(args):

--- a/client/scripts/control.py
+++ b/client/scripts/control.py
@@ -101,12 +101,12 @@ class ClientsController(object):
             conn.send(msg)
         elif data == "graceful_restart":
             msg = self.send_signal(signal.SIGUSR2)
-            for proc in self.processes.values():
+            for proc in list(self.processes.values()):
                 proc["need_restart"] = True
             conn.send(msg)
         elif data == "status":
             msg = ""
-            for p in self.processes.values():
+            for p in list(self.processes.values()):
                 runtime = p.get("runtime", 0)
                 alive = "Dead"
                 if p["process"].poll() == None:
@@ -144,7 +144,7 @@ class ClientsController(object):
           str: information on what happened
         """
         ret = ""
-        for proc in self.processes.values():
+        for proc in list(self.processes.values()):
             if proc["process"].poll() == None:
                 try:
                     os.kill(proc["process"].pid, sig)
@@ -162,7 +162,7 @@ class ClientsController(object):
           str: information on what happened
         """
         ret = ""
-        for proc in self.processes.values():
+        for proc in list(self.processes.values()):
             msg = self.kill_proc(proc)
             if msg:
                 ret += msg + "\n"
@@ -197,7 +197,7 @@ class ClientsController(object):
           str: information on what happened
         """
         msg = ""
-        for i in self.jobs.keys():
+        for i in list(self.jobs.keys()):
             msg += self.start_proc(i) + "\n"
         return msg
 
@@ -227,9 +227,9 @@ class ClientsController(object):
         """
         Check to see if we need to restart any processes
         """
-        for idx, proc in self.processes.items():
+        for idx, proc in list(self.processes.items()):
             if proc.get("need_restart", False) and proc["process"].poll() is not None:
-                print("Starting new process on index %s" % idx)
+                print(("Starting new process on index %s" % idx))
                 self.start_proc(idx)
                 proc["need_restart"] = False
 
@@ -237,7 +237,7 @@ class ClientsController(object):
         """
         Check to see if any processes are dead.
         """
-        for idx, proc in self.processes.items():
+        for idx, proc in list(self.processes.items()):
             if proc["running"] and proc["process"].poll() is not None:
                 proc["runtime"] = time.time() - proc["start"]
                 proc["running"] = False
@@ -247,7 +247,7 @@ class ClientsController(object):
         Main loop
         """
         self.create_socket()
-        for i in self.jobs.keys():
+        for i in list(self.jobs.keys()):
             self.start_proc(i)
 
         while not self.shutdown:

--- a/client/scripts/control.py
+++ b/client/scripts/control.py
@@ -22,6 +22,7 @@ This launches settings.NUM_CLIENTS instances of the INLClient and keeps them as 
 The primarly purpose and main improvement over the bash script is that this allows for easier
 restarting with a fresh copy of the client python code.
 """
+from __future__ import unicode_literals
 import sys, argparse, os
 import settings
 import subprocess
@@ -101,12 +102,12 @@ class ClientsController(object):
             conn.send(msg)
         elif data == "graceful_restart":
             msg = self.send_signal(signal.SIGUSR2)
-            for proc in list(self.processes.values()):
+            for proc in self.processes.values():
                 proc["need_restart"] = True
             conn.send(msg)
         elif data == "status":
             msg = ""
-            for p in list(self.processes.values()):
+            for p in self.processes.values():
                 runtime = p.get("runtime", 0)
                 alive = "Dead"
                 if p["process"].poll() == None:
@@ -144,7 +145,7 @@ class ClientsController(object):
           str: information on what happened
         """
         ret = ""
-        for proc in list(self.processes.values()):
+        for proc in self.processes.values():
             if proc["process"].poll() == None:
                 try:
                     os.kill(proc["process"].pid, sig)
@@ -162,7 +163,7 @@ class ClientsController(object):
           str: information on what happened
         """
         ret = ""
-        for proc in list(self.processes.values()):
+        for proc in self.processes.values():
             msg = self.kill_proc(proc)
             if msg:
                 ret += msg + "\n"
@@ -197,7 +198,7 @@ class ClientsController(object):
           str: information on what happened
         """
         msg = ""
-        for i in list(self.jobs.keys()):
+        for i in self.jobs.keys():
             msg += self.start_proc(i) + "\n"
         return msg
 
@@ -227,9 +228,9 @@ class ClientsController(object):
         """
         Check to see if we need to restart any processes
         """
-        for idx, proc in list(self.processes.items()):
+        for idx, proc in self.processes.items():
             if proc.get("need_restart", False) and proc["process"].poll() is not None:
-                print(("Starting new process on index %s" % idx))
+                print("Starting new process on index %s" % idx)
                 self.start_proc(idx)
                 proc["need_restart"] = False
 
@@ -237,7 +238,7 @@ class ClientsController(object):
         """
         Check to see if any processes are dead.
         """
-        for idx, proc in list(self.processes.items()):
+        for idx, proc in self.processes.items():
             if proc["running"] and proc["process"].poll() is not None:
                 proc["runtime"] = time.time() - proc["start"]
                 proc["running"] = False
@@ -247,7 +248,7 @@ class ClientsController(object):
         Main loop
         """
         self.create_socket()
-        for i in list(self.jobs.keys()):
+        for i in self.jobs.keys():
             self.start_proc(i)
 
         while not self.shutdown:

--- a/client/tests/LiveClientTester.py
+++ b/client/tests/LiveClientTester.py
@@ -15,7 +15,7 @@
 
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from ci.tests import DBTester
-import utils
+from . import utils
 
 class LiveClientTester(StaticLiveServerTestCase, DBTester.DBCompare):
     def setUp(self):

--- a/client/tests/LiveClientTester.py
+++ b/client/tests/LiveClientTester.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from ci.tests import DBTester
 from . import utils

--- a/client/tests/test_BaseClient.py
+++ b/client/tests/test_BaseClient.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import SimpleTestCase
 from django.test import override_settings
 from client import BaseClient

--- a/client/tests/test_BaseClient_live.py
+++ b/client/tests/test_BaseClient_live.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from client import JobGetter
 from django.test import override_settings
 from mock import patch
@@ -84,7 +85,13 @@ class Tests(LiveClientTester.LiveClientTester):
             proc = subprocess.Popen(script, shell=True, executable="/bin/bash", stdout=subprocess.PIPE)
             c.run()
             proc.wait()
-            self.compare_counts(canceled=1, num_clients=1, num_events_completed=1, num_jobs_completed=1, active_branches=1, events_canceled=1)
+            self.compare_counts(canceled=1,
+                    num_clients=1,
+                    num_events_completed=1,
+                    num_jobs_completed=1,
+                    active_branches=1,
+                    events_canceled=1,
+                    )
             self.assertEqual(c.cancel_signal.triggered, True)
             self.assertEqual(c.graceful_signal.triggered, False)
             utils.check_canceled_job(self, job)
@@ -100,7 +107,13 @@ class Tests(LiveClientTester.LiveClientTester):
             job.refresh_from_db()
             views.set_job_canceled(job)
             thread.join()
-            self.compare_counts(canceled=1, num_clients=1, num_events_completed=1, num_jobs_completed=1, active_branches=1, events_canceled=1)
+            self.compare_counts(canceled=1,
+                    num_clients=1,
+                    num_events_completed=1,
+                    num_jobs_completed=1,
+                    active_branches=1,
+                    events_canceled=1,
+                    )
             self.assertEqual(c.cancel_signal.triggered, False)
             self.assertEqual(c.graceful_signal.triggered, False)
             utils.check_canceled_job(self, job)

--- a/client/tests/test_BaseClient_live.py
+++ b/client/tests/test_BaseClient_live.py
@@ -22,7 +22,7 @@ import threading
 import time
 from ci import views
 from ci.tests import utils as test_utils
-import LiveClientTester
+from . import LiveClientTester
 
 @override_settings(INSTALLED_GITSERVERS=[test_utils.github_config()])
 class Tests(LiveClientTester.LiveClientTester):

--- a/client/tests/test_INLClient.py
+++ b/client/tests/test_INLClient.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import SimpleTestCase
 from django.test import override_settings
 from ci.tests import utils as test_utils

--- a/client/tests/test_INLClient_live.py
+++ b/client/tests/test_INLClient_live.py
@@ -19,12 +19,12 @@ from mock import patch
 from client.JobGetter import JobGetter
 from client import settings
 import subprocess
-import utils
+from . import utils
 import threading
 import time
 from ci import views
 from ci.tests import utils as test_utils
-import LiveClientTester
+from . import LiveClientTester
 
 @override_settings(INSTALLED_GITSERVERS=[test_utils.github_config()])
 class Tests(LiveClientTester.LiveClientTester):

--- a/client/tests/test_INLClient_live.py
+++ b/client/tests/test_INLClient_live.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import os
 from django.test import override_settings
 from mock import patch

--- a/client/tests/test_InterruptHandler.py
+++ b/client/tests/test_InterruptHandler.py
@@ -18,7 +18,7 @@ from django.test import override_settings
 from ci.tests import utils as test_utils
 from client import InterruptHandler
 import signal, os, subprocess
-from Queue import Queue
+from queue import Queue
 
 @override_settings(INSTALLED_GITSERVERS=[test_utils.github_config()])
 class InterruptHandlerTests(SimpleTestCase):

--- a/client/tests/test_InterruptHandler.py
+++ b/client/tests/test_InterruptHandler.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import SimpleTestCase
 from django.test import override_settings
 from ci.tests import utils as test_utils

--- a/client/tests/test_JobGetter.py
+++ b/client/tests/test_JobGetter.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import requests
 from . import utils
 from django.test import override_settings
@@ -36,7 +37,7 @@ class Tests(DBTester.DBTester):
 
         # test the non error operation
         job_response = {"jobs": "jobs"}
-        mock_get.return_value = utils.MockResponse(job_response)
+        mock_get.return_value = test_utils.Response(job_response)
         self.set_counts()
         jobs = g.get_possible_jobs()
         self.assertEqual(jobs, job_response["jobs"])
@@ -44,14 +45,14 @@ class Tests(DBTester.DBTester):
 
         # check when the server responds incorrectly
         job_response = {"none": "none"}
-        mock_get.return_value = utils.MockResponse(job_response)
+        mock_get.return_value = test_utils.Response(job_response)
         self.set_counts()
         jobs = g.get_possible_jobs()
         self.compare_counts()
         self.assertEqual(jobs, None)
 
         # check when requests has bad status code
-        mock_get.return_value = utils.MockResponse(job_response, do_raise=True)
+        mock_get.return_value = test_utils.Response(job_response, do_raise=True)
         self.set_counts()
         jobs = g.get_possible_jobs()
         self.compare_counts()
@@ -65,7 +66,7 @@ class Tests(DBTester.DBTester):
         jobs = [j0, j1]
         response_data = utils.create_json_response()
         response_data['job_info'] = {'recipe_name': 'test'}
-        mock_post.return_value = utils.MockResponse(response_data)
+        mock_post.return_value = test_utils.Response(response_data)
         # successfull operation
         self.set_counts()
         ret = g.claim_job(jobs)
@@ -74,7 +75,7 @@ class Tests(DBTester.DBTester):
 
         # didn't succeed
         response_data["success"] = False
-        mock_post.return_value = utils.MockResponse(response_data)
+        mock_post.return_value = test_utils.Response(response_data)
         self.set_counts()
         ret = g.claim_job(jobs)
         self.compare_counts()
@@ -88,7 +89,7 @@ class Tests(DBTester.DBTester):
         self.assertEqual(ret, None)
 
         # try when server problems
-        mock_post.return_value = utils.MockResponse(response_data, do_raise=True)
+        mock_post.return_value = test_utils.Response(response_data, do_raise=True)
         self.set_counts()
         ret = g.claim_job(jobs)
         self.compare_counts()
@@ -102,10 +103,10 @@ class Tests(DBTester.DBTester):
         j0 = {"config": "unknown_config", "id": 1}
         j1 = {"config": g.client_info["build_configs"][0], "id": 2}
         jobs = [j0, j1]
-        mock_get.return_value = utils.MockResponse({"jobs": jobs})
+        mock_get.return_value = test_utils.Response({"jobs": jobs})
         response_data = utils.create_json_response()
         response_data['job_info'] = {'recipe_name': 'test'}
-        mock_post.return_value = utils.MockResponse(response_data)
+        mock_post.return_value = test_utils.Response(response_data)
 
         # normal operation
         self.set_counts()
@@ -114,7 +115,7 @@ class Tests(DBTester.DBTester):
         self.assertEqual(result, response_data)
 
         # no jobs
-        mock_get.return_value = utils.MockResponse([])
+        mock_get.return_value = test_utils.Response([])
         self.set_counts()
         result = g.find_job()
         self.compare_counts()

--- a/client/tests/test_JobGetter_live.py
+++ b/client/tests/test_JobGetter_live.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from client import JobGetter
 from django.test import override_settings
 from ci.tests import utils as test_utils

--- a/client/tests/test_JobGetter_live.py
+++ b/client/tests/test_JobGetter_live.py
@@ -18,7 +18,7 @@ from django.test import override_settings
 from ci.tests import utils as test_utils
 from ci import models
 import json, os
-import LiveClientTester
+from . import LiveClientTester
 from mock import patch
 from client import BaseClient
 import requests

--- a/client/tests/test_JobRunner.py
+++ b/client/tests/test_JobRunner.py
@@ -23,7 +23,7 @@ from mock import patch
 from client import BaseClient
 BaseClient.setup_logger()
 
-from Queue import Queue, Empty
+from queue import Queue, Empty
 
 @override_settings(INSTALLED_GITSERVERS=[test_utils.github_config()])
 class Tests(SimpleTestCase):
@@ -51,7 +51,7 @@ class Tests(SimpleTestCase):
         self.assertEqual(results['client_name'], runner.client_info["client_name"])
         self.assertEqual(self.message_q.qsize(), 1)
         msg = self.message_q.get(block=False)
-        self.assertEqual(len(msg.keys()), 4)
+        self.assertEqual(len(list(msg.keys())), 4)
         server = runner.client_info["server"]
         self.assertEqual(msg["server"], server)
         self.assertTrue(msg["url"].startswith(server))
@@ -109,7 +109,7 @@ class Tests(SimpleTestCase):
             r.update_step(stage, step, chunk_data)
             self.assertEqual(self.message_q.qsize(), 1)
             msg = self.message_q.get(block=False)
-            self.assertEqual(len(msg.keys()), 4)
+            self.assertEqual(len(list(msg.keys())), 4)
             server = r.client_info["server"]
             self.assertEqual(msg["server"], server)
             self.assertTrue(msg["url"].startswith(server))

--- a/client/tests/test_JobRunner.py
+++ b/client/tests/test_JobRunner.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import SimpleTestCase
 from django.test import override_settings
 from ci.tests import utils as test_utils
@@ -164,7 +165,7 @@ class Tests(SimpleTestCase):
         r = self.create_runner()
         r.client_info["update_step_time"] = 1
         with JobRunner.temp_file() as script_file:
-            script = "for i in $(seq 5);do echo start $i; sleep 1; echo done $i; done"
+            script = b"for i in $(seq 5);do echo start $i; sleep 1; echo done $i; done"
             script_file.write(script)
             script_file.close()
             with open(os.devnull, "wb") as devnull:
@@ -215,7 +216,7 @@ class Tests(SimpleTestCase):
 
     def test_kill_job(self):
         with JobRunner.temp_file() as script:
-            script.write("sleep 30")
+            script.write(b"sleep 30")
             script.close()
             with open(os.devnull, "wb") as devnull:
                 r = self.create_runner()
@@ -295,7 +296,7 @@ class Tests(SimpleTestCase):
 
     def test_max_step_time(self):
         with JobRunner.temp_file() as script:
-            script.write("sleep 30")
+            script.write(b"sleep 30")
             script.close()
             with open(os.devnull, "wb") as devnull:
                 r = self.create_runner()

--- a/client/tests/test_Modules.py
+++ b/client/tests/test_Modules.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import SimpleTestCase
 from django.test import override_settings
 from ci.tests import utils as test_utils
@@ -52,7 +53,7 @@ class Tests(SimpleTestCase):
     @patch.object(subprocess, "Popen")
     def test_bad_output(self, mock_popen):
         mod = Modules.Modules()
-        mock_popen.return_value = MockPopen(0, "no out", "no err")
+        mock_popen.return_value = MockPopen(0, b"no out", b"no err")
         mod.command("list")
 
         with self.assertRaises(Exception):

--- a/client/tests/test_ServerUpdater.py
+++ b/client/tests/test_ServerUpdater.py
@@ -27,7 +27,7 @@ from client import BaseClient
 BaseClient.setup_logger()
 
 try:
-    from Queue import Queue, Empty
+    from queue import Queue, Empty
 except ImportError:
     from queue import Queue, Empty # Python 3.x
 
@@ -271,7 +271,7 @@ class Tests(SimpleTestCase):
         item = {"server": u.main_server, "job_id": 0, "url": "url", "payload": {"output": 'foo \xe0 \xe0 bar'}}
         u.message_q.put(item)
         u.post_message(item)
-        self.assertEquals(item["payload"]["output"], "foo \xef\xbf\xbd \xef\xbf\xbd bar")
+        self.assertEqual(item["payload"]["output"], "foo \xef\xbf\xbd \xef\xbf\xbd bar")
 
         # Enforce a JSON serializable error
         class BadObject(object):

--- a/client/tests/test_ServerUpdater.py
+++ b/client/tests/test_ServerUpdater.py
@@ -272,7 +272,6 @@ class Tests(SimpleTestCase):
         u = self.create_updater()
         mock_post.return_value = test_utils.Response({"not_empty": True})
         item = {"server": u.main_server, "job_id": 0, "url": "url", "payload": {"output": u'foo \xe0 \xe0 bar'}}
-        print("Output: %s" % item["payload"]["output"])
         u.message_q.put(item)
         u.post_message(item)
         # self.assertEqual(item["payload"]["output"], "foo \xef\xbf\xbd \xef\xbf\xbd bar")

--- a/client/tests/test_ServerUpdater.py
+++ b/client/tests/test_ServerUpdater.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import SimpleTestCase
 from django.test import override_settings
 from ci.tests import utils as test_utils
@@ -72,7 +73,7 @@ class Tests(SimpleTestCase):
         self.thread = Thread(target=ServerUpdater.ServerUpdater.run, args=(u,))
         self.thread.start()
         response_data = {"status": "OK"}
-        mock_post.return_value = utils.MockResponse(response_data)
+        mock_post.return_value = test_utils.Response(response_data)
         server = u.client_info["servers"][0]
         item = {"server": server, "job_id": 0, "url": "url", "payload": {"message": "message"}}
         self.message_q.put(item)
@@ -134,7 +135,7 @@ class Tests(SimpleTestCase):
     @patch.object(requests, 'post')
     def test_send_messages_ok(self, mock_post):
         u = self.create_updater()
-        mock_post.return_value = utils.MockResponse({"status": "OK"})
+        mock_post.return_value = test_utils.Response({"status": "OK"})
         items = self.load_messages(u)
         self.assertEqual(u.messages, items)
         self.assertEqual(mock_post.call_count, 0)
@@ -149,7 +150,7 @@ class Tests(SimpleTestCase):
         # got the stop signal
         self.load_messages(u)
         response_data = {"status": "OK"}
-        mock_post.side_effect = [utils.MockResponse(response_data), utils.MockResponse(response_data, status_code=400)]
+        mock_post.side_effect = [test_utils.Response(response_data), test_utils.Response(response_data, status_code=400)]
         u.send_messages()
         self.assertEqual(u.messages, [])
         self.assertEqual(mock_post.call_count, 2)
@@ -160,7 +161,7 @@ class Tests(SimpleTestCase):
         # got the cancel signal
         self.load_messages(u)
         response_data = {"status": "OK", "command": "cancel"}
-        mock_post.return_value = utils.MockResponse(response_data)
+        mock_post.return_value = test_utils.Response(response_data)
         u.send_messages()
         self.assertEqual(u.messages, [])
         self.assertEqual(mock_post.call_count, 3)
@@ -172,7 +173,7 @@ class Tests(SimpleTestCase):
         response_data = {"status": "OK"}
         items = self.load_messages(u)
         mock_post.call_count = 0
-        mock_post.return_value = utils.MockResponse(response_data, do_raise=True)
+        mock_post.return_value = test_utils.Response(response_data, do_raise=True)
         u.send_messages()
         self.assertEqual(u.messages, items)
         self.assertEqual(mock_post.call_count, 1)
@@ -184,7 +185,9 @@ class Tests(SimpleTestCase):
         items = self.load_messages(u)
         mock_post.call_count = 0
         response_data = {"status": "OK"}
-        mock_post.side_effect = [utils.MockResponse(response_data), utils.MockResponse(response_data), utils.MockResponse(response_data, do_raise=True)]
+        good_response = test_utils.Response(response_data)
+        bad_response = test_utils.Response(response_data, do_raise=True)
+        mock_post.side_effect = [good_response, good_response, bad_response]
         u.send_messages()
         self.assertEqual(u.messages, items[2:])
         self.assertEqual(mock_post.call_count, 3)
@@ -196,7 +199,7 @@ class Tests(SimpleTestCase):
         response_data = {"bad_key": "val"}
         self.load_messages(u)
         mock_post.call_count = 0
-        mock_post.return_value = utils.MockResponse(response_data)
+        mock_post.return_value = test_utils.Response(response_data)
         u.send_messages()
         self.assertEqual(u.messages, [])
         self.assertEqual(mock_post.call_count, 3)
@@ -209,7 +212,7 @@ class Tests(SimpleTestCase):
         self.load_messages(u)
         mock_post.call_count = 0
         response_data = {"status": "NOT OK"}
-        mock_post.return_value = utils.MockResponse(response_data)
+        mock_post.return_value = test_utils.Response(response_data)
         u.send_messages()
         self.assertEqual(u.messages, [])
         self.assertEqual(mock_post.call_count, 3)
@@ -217,7 +220,7 @@ class Tests(SimpleTestCase):
     @patch.object(requests, 'post')
     def test_ping_servers(self, mock_post):
         u = self.create_updater()
-        mock_post.return_value = utils.MockResponse({"not_empty": True})
+        mock_post.return_value = test_utils.Response({"not_empty": True})
         u.client_info["server_update_interval"] = 1
         # not enough elapsed time from creation
         u.ping_servers()
@@ -234,12 +237,12 @@ class Tests(SimpleTestCase):
     @patch.object(requests, 'post')
     def test_ping_server(self, mock_post):
         u = self.create_updater()
-        mock_post.return_value = utils.MockResponse({"not_empty": True})
+        mock_post.return_value = test_utils.Response({"not_empty": True})
         ret = u.ping_server("server", "message")
         self.assertEqual(ret, True)
 
         # server didn't respond correctly
-        mock_post.return_value = utils.MockResponse({}, do_raise=True)
+        mock_post.return_value = test_utils.Response({}, do_raise=True)
         ret = u.ping_server("server", "message")
         self.assertEqual(ret, False)
 
@@ -250,28 +253,30 @@ class Tests(SimpleTestCase):
         response_data = utils.create_json_response()
         url = 'foo'
         # test the non error operation
-        mock_post.return_value = utils.MockResponse(response_data)
+        mock_post.return_value = test_utils.Response(response_data)
         ret = u.post_json(url, in_data)
         self.assertEqual(ret, response_data)
 
-        mock_post.return_value = utils.MockResponse(response_data, do_raise=True)
+        mock_post.return_value = test_utils.Response(response_data, do_raise=True)
         #check when the server responds incorrectly
         ret = u.post_json(url, in_data)
         self.assertEqual(ret, None)
 
         #check when the server gives bad request
-        mock_post.return_value = utils.MockResponse(response_data, status_code=400)
+        mock_post.return_value = test_utils.Response(response_data, status_code=400)
         ret = u.post_json(url, in_data)
         self.assertEqual(ret, {"status": "OK", "command": "stop"})
 
     @patch.object(requests, 'post')
     def test_bad_output(self, mock_post):
         u = self.create_updater()
-        mock_post.return_value = utils.MockResponse({"not_empty": True})
-        item = {"server": u.main_server, "job_id": 0, "url": "url", "payload": {"output": 'foo \xe0 \xe0 bar'}}
+        mock_post.return_value = test_utils.Response({"not_empty": True})
+        item = {"server": u.main_server, "job_id": 0, "url": "url", "payload": {"output": u'foo \xe0 \xe0 bar'}}
+        print("Output: %s" % item["payload"]["output"])
         u.message_q.put(item)
         u.post_message(item)
-        self.assertEqual(item["payload"]["output"], "foo \xef\xbf\xbd \xef\xbf\xbd bar")
+        # self.assertEqual(item["payload"]["output"], "foo \xef\xbf\xbd \xef\xbf\xbd bar")
+        self.assertEqual(item["payload"]["output"], "foo \xe0 \xe0 bar")
 
         # Enforce a JSON serializable error
         class BadObject(object):

--- a/client/tests/test_ServerUpdater_live.py
+++ b/client/tests/test_ServerUpdater_live.py
@@ -18,8 +18,8 @@ from django.test import override_settings
 from ci.tests import utils as test_utils
 from client import ServerUpdater
 from ci import models
-import LiveClientTester
-from Queue import Queue
+from . import LiveClientTester
+from queue import Queue
 
 from client import BaseClient
 BaseClient.setup_logger()
@@ -35,7 +35,7 @@ class Tests(LiveClientTester.LiveClientTester):
         self.updater = None
         self.updater = ServerUpdater.ServerUpdater(self.client_info["servers"][0], self.client_info, self.message_q, self.command_q, self.control_q)
         self.assertEqual(self.updater.running, True)
-        self.assertEqual(self.updater.servers.keys(), self.client_info["servers"])
+        self.assertEqual(list(self.updater.servers.keys()), self.client_info["servers"])
         self.assertEqual(self.updater.messages, [])
 
     def tearDown(self):

--- a/client/tests/test_ServerUpdater_live.py
+++ b/client/tests/test_ServerUpdater_live.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import time
 from django.test import override_settings
 from ci.tests import utils as test_utils

--- a/client/tests/test_client.py
+++ b/client/tests/test_client.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import SimpleTestCase
 from django.test import override_settings
 from ci.tests import utils as test_utils

--- a/client/tests/test_inl_client.py
+++ b/client/tests/test_inl_client.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import SimpleTestCase
 from django.test import override_settings
 from ci.tests import utils as test_utils

--- a/client/tests/utils.py
+++ b/client/tests/utils.py
@@ -13,23 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import os, json
 from client import BaseClient, INLClient
 from ci.tests import utils
 from ci import models
-
-class MockResponse(object):
-    def __init__(self, in_json, do_raise=False, status_code=200):
-        self.in_json = in_json
-        self.do_raise = do_raise
-        self.status_code = status_code
-
-    def json(self):
-        return self.in_json
-
-    def raise_for_status(self):
-        if self.do_raise:
-            raise Exception("Bad response status code")
 
 def create_json_response(canceled=False, success=True):
     ret = {'status': 'OK'}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 ansi2html==1.3.0
+attrs==17.4.0
 certifi==2017.11.5
 chardet==3.0.4
 coverage==4.4.2
@@ -10,12 +11,16 @@ django-extensions==1.9.9
 django-graphos==0.3.41
 django-sslserver==0.20
 funcsigs==1.0.2
+future==0.16.0
 idna==2.6
 mock==2.0.0
 oauthlib==2.0.6
 pbr==3.1.1
+pluggy==0.6.0
+py==1.5.2
 py-w3c==0.3.1
 pyflakes==1.6.0
+pytest==3.3.2
 pytz==2017.3
 requests==2.18.4
 requests-oauthlib==0.8.0


### PR DESCRIPTION
Future versions of Django drop support for python2.
This adopts the general Django philosophy of writing python3 code that is compatible with python2 rather than the reverse.