### PR TITLE
Use unicode_literals

### DIFF
--- a/ci/DebugViews.py
+++ b/ci/DebugViews.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.http import HttpResponse, Http404
 from django.conf import settings
 from django.shortcuts import redirect, get_object_or_404

--- a/ci/EventsStatus.py
+++ b/ci/EventsStatus.py
@@ -161,21 +161,21 @@ def events_info(events, last_modified=None, events_url=False):
 
         repo_url = reverse("ci:view_repo", args=[ev.base.branch.repository.pk])
         event_url = reverse("ci:view_event", args=[ev.pk])
-        repo_link = format_html(u'<a href="{}">{}</a>', repo_url, ev.base.branch.repository.name)
+        repo_link = format_html('<a href="{}">{}</a>', repo_url, ev.base.branch.repository.name)
         pr_url = ''
         pr_desc = ''
         if ev.pull_request:
             pr_url = reverse("ci:view_pr", args=[ev.pull_request.pk])
             pr_desc = clean_str_for_format(str(ev.pull_request))
-            icon_link = format_html(u'<a href="{}"><i class="{}"></i></a>', ev.pull_request.url, ev.base.server().icon_class())
+            icon_link = format_html('<a href="{}"><i class="{}"></i></a>', ev.pull_request.url, ev.base.server().icon_class())
             if events_url:
-                event_desc = format_html(u'{} {} <a href="{}">{}</a>', icon_link, repo_link, event_url, pr_desc)
+                event_desc = format_html('{} {} <a href="{}">{}</a>', icon_link, repo_link, event_url, pr_desc)
             else:
-                event_desc = format_html(u'{} {} <a href="{}">{}</a>', icon_link, repo_link, pr_url, pr_desc)
+                event_desc = format_html('{} {} <a href="{}">{}</a>', icon_link, repo_link, pr_url, pr_desc)
         else:
-            event_desc = format_html(u'{} <a href="{}">{}', repo_link, event_url, ev.base.branch.name)
+            event_desc = format_html('{} <a href="{}">{}', repo_link, event_url, ev.base.branch.name)
             if ev.description:
-                event_desc = format_html(u'{} : {}', mark_safe(event_desc), clean_str_for_format(ev.description))
+                event_desc = format_html('{} : {}', mark_safe(event_desc), clean_str_for_format(ev.description))
             event_desc += '</a>'
 
         info = { 'id': ev.pk,
@@ -215,9 +215,9 @@ def events_info(events, last_modified=None, events_url=False):
                 jinfo = { 'id': job.pk,
                     'status': job.status_slug(),
                     }
-                job_desc = format_html(u'<a href="{}">{}</a>', jurl, format_html(job.unique_name()))
+                job_desc = format_html('<a href="{}">{}</a>', jurl, format_html(job.unique_name()))
                 if job_seconds:
-                    job_desc += format_html(u'<br />{}', job_seconds)
+                    job_desc += format_html('<br />{}', job_seconds)
                 if job.failed_step:
                     job_desc += format_html('<br />{}', job.failed_step)
                 if job.invalidated:

--- a/ci/EventsStatus.py
+++ b/ci/EventsStatus.py
@@ -18,6 +18,7 @@ from ci import TimeUtils, models
 from django.urls import reverse
 from django.utils.html import format_html, mark_safe
 import copy
+from django.utils.encoding import force_text
 
 def get_default_events_query(event_q=None):
     """
@@ -88,7 +89,7 @@ def events_filter_by_repo(pks, limit=30, last_modified=None):
     return multiline_events_info(event_q, last_modified)
 
 def clean_str_for_format(s):
-    new_s = s.replace("{", "{{")
+    new_s = force_text(s).replace("{", "{{")
     new_s = new_s.replace("}", "}}")
     words = []
     # Really long words cause havoc on the table of events.

--- a/ci/EventsStatus.py
+++ b/ci/EventsStatus.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci import TimeUtils, models
 from django.urls import reverse
 from django.utils.html import format_html, mark_safe

--- a/ci/GitCommitData.py
+++ b/ci/GitCommitData.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import models
 import logging
 logger = logging.getLogger('ci')

--- a/ci/ManualEvent.py
+++ b/ci/ManualEvent.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import models
 import GitCommitData
 import logging

--- a/ci/Permissions.py
+++ b/ci/Permissions.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import TimeUtils
 import logging
 from ci import models

--- a/ci/PullRequestEvent.py
+++ b/ci/PullRequestEvent.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import models
 from django.urls import reverse
 import traceback

--- a/ci/PushEvent.py
+++ b/ci/PushEvent.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import models
 import logging
 from ci import views

--- a/ci/ReleaseEvent.py
+++ b/ci/ReleaseEvent.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import models
 import logging
 logger = logging.getLogger('ci')

--- a/ci/RepositoryStatus.py
+++ b/ci/RepositoryStatus.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci import models
 from django.db.models import Prefetch
 from django.urls import reverse

--- a/ci/Stats.py
+++ b/ci/Stats.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.shortcuts import render
 from ci import models, TimeUtils
 from graphos.sources.simple import SimpleDataSource

--- a/ci/TimeUtils.py
+++ b/ci/TimeUtils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.utils import timezone
 import datetime, math

--- a/ci/admin.py
+++ b/ci/admin.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.contrib import admin
 from . import models
 

--- a/ci/ajax/tests/test_views.py
+++ b/ci/ajax/tests/test_views.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.urls import reverse
 from django.utils.html import escape
 from ci.tests import utils

--- a/ci/ajax/tests/test_views.py
+++ b/ci/ajax/tests/test_views.py
@@ -74,7 +74,7 @@ class Tests(DBTester.DBTester):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
 
-        pr = utils.create_pr(title=u"Foo <type> & bar …")
+        pr = utils.create_pr(title="Foo <type> & bar …")
         url = reverse('ci:ajax:pr_update', args=[pr.pk])
 
         response = self.client.get(url)
@@ -102,7 +102,7 @@ class Tests(DBTester.DBTester):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 400)
 
-        pr_open = utils.create_pr(title=u'Foo <type> & bar …', number=1)
+        pr_open = utils.create_pr(title='Foo <type> & bar …', number=1)
         ev_open = utils.create_event()
         pr_open.closed = False
         pr_open.save()
@@ -210,7 +210,7 @@ class Tests(DBTester.DBTester):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 400)
 
-        pr_open = utils.create_pr(title=u'Foo <type> & bar …', number=1)
+        pr_open = utils.create_pr(title='Foo <type> & bar …', number=1)
         ev_open = utils.create_event()
         pr_open.closed = False
         pr_open.save()

--- a/ci/ajax/urls.py
+++ b/ci/ajax/urls.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.conf.urls import url
 from . import views
 

--- a/ci/ajax/views.py
+++ b/ci/ajax/views.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.utils import timezone
 from django.http import JsonResponse, HttpResponseBadRequest, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, render

--- a/ci/bitbucket/api.py
+++ b/ci/bitbucket/api.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.urls import reverse
 import logging
 import requests

--- a/ci/bitbucket/oauth.py
+++ b/ci/bitbucket/oauth.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci.oauth_api import OAuth
 from django.conf import settings
 from django.urls import reverse

--- a/ci/bitbucket/tests/test_api.py
+++ b/ci/bitbucket/tests/test_api.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import TestCase, Client
 from django.urls import reverse
 from django.test.client import RequestFactory

--- a/ci/bitbucket/tests/test_oauth.py
+++ b/ci/bitbucket/tests/test_oauth.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import TestCase, RequestFactory, Client
 from django.urls import reverse
 from django.conf import settings

--- a/ci/bitbucket/tests/test_views.py
+++ b/ci/bitbucket/tests/test_views.py
@@ -44,12 +44,12 @@ class Tests(DBTester.DBTester):
         # only post allowed
         response = self.client.get(url)
         self.assertEqual(response.status_code, 405) # not allowed
-        self.assertNotEqual(response.content, "OK")
+        self.assertNotEqual(response.content, b"OK")
 
         # no user
         response = self.client.post(url)
         self.assertEqual(response.status_code, 400)
-        self.assertNotEqual(response.content, "OK")
+        self.assertNotEqual(response.content, b"OK")
 
         # no json
         user = utils.get_test_user(server=self.server)
@@ -57,14 +57,14 @@ class Tests(DBTester.DBTester):
         data = {'key': 'value'}
         response = self.client.post(url, data)
         self.assertEqual(response.status_code, 400)
-        self.assertNotEqual(response.content, "OK")
+        self.assertNotEqual(response.content, b"OK")
 
         # bad json
         user = utils.get_test_user(self.server)
         url = reverse('ci:bitbucket:webhook', args=[user.build_key])
         response = self.client_post_json(url, data)
         self.assertEqual(response.status_code, 400)
-        self.assertNotEqual(response.content, "OK")
+        self.assertNotEqual(response.content, b"OK")
 
     def test_pull_request(self):
         url = reverse('ci:bitbucket:webhook', args=[self.build_user.build_key])
@@ -77,21 +77,21 @@ class Tests(DBTester.DBTester):
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
         self.compare_counts(jobs=2, ready=1, events=1, commits=2, users=1, repos=1, branches=1, prs=1, active=2, active_repos=1, num_git_events=1)
 
         py_data['pullrequest']['state'] = 'DECLINED'
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
         self.compare_counts(pr_closed=True, num_git_events=1)
 
         py_data['pullrequest']['state'] = 'BadState'
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 400)
-        self.assertNotEqual(response.content, "OK")
+        self.assertNotEqual(response.content, b"OK")
         self.compare_counts(pr_closed=True, num_git_events=1)
 
     def test_push(self):
@@ -107,7 +107,7 @@ class Tests(DBTester.DBTester):
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
         self.compare_counts(jobs=2, ready=1, events=1, commits=2, active=2, active_repos=1, num_git_events=1)
         ev = models.Event.objects.latest()
         self.assertEqual(ev.cause, models.Event.PUSH)
@@ -117,7 +117,7 @@ class Tests(DBTester.DBTester):
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
         self.compare_counts(num_git_events=1)
 
         # Sometimes the new data isn't there
@@ -125,7 +125,7 @@ class Tests(DBTester.DBTester):
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 400)
-        self.assertNotEqual(response.content, "OK")
+        self.assertNotEqual(response.content, b"OK")
         self.compare_counts(num_git_events=1)
 
         # Sometimes the old data isn't there
@@ -133,5 +133,5 @@ class Tests(DBTester.DBTester):
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 400)
-        self.assertNotEqual(response.content, "OK")
+        self.assertNotEqual(response.content, b"OK")
         self.compare_counts(num_git_events=1)

--- a/ci/bitbucket/tests/test_views.py
+++ b/ci/bitbucket/tests/test_views.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.urls import reverse
 from django.test import override_settings
 from django.conf import settings

--- a/ci/bitbucket/urls.py
+++ b/ci/bitbucket/urls.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.conf.urls import url
 from ci.bitbucket import oauth, views
 

--- a/ci/bitbucket/views.py
+++ b/ci/bitbucket/views.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.views.decorators.csrf import csrf_exempt
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseNotAllowed
 import logging, traceback

--- a/ci/client/ParseOutput.py
+++ b/ci/client/ParseOutput.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci import models
 import re
 

--- a/ci/client/ProcessCommands.py
+++ b/ci/client/ProcessCommands.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci import models
 import re
 

--- a/ci/client/UpdateRemoteStatus.py
+++ b/ci/client/UpdateRemoteStatus.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci import models
 from django.urls import reverse
 import ProcessCommands

--- a/ci/client/tests/ClientTester.py
+++ b/ci/client/tests/ClientTester.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import os
 from ci.tests import utils, DBTester
 from ci.client import ParseOutput

--- a/ci/client/tests/test_ParseOutput.py
+++ b/ci/client/tests/test_ParseOutput.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import ClientTester
 from ci.client import ParseOutput
 from ci.tests import utils

--- a/ci/client/tests/test_ProcessCommands.py
+++ b/ci/client/tests/test_ProcessCommands.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import ClientTester
 from django.test import override_settings
 from ci.client import ProcessCommands

--- a/ci/client/tests/test_UpdateRemoteStatus.py
+++ b/ci/client/tests/test_UpdateRemoteStatus.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import override_settings
 import ClientTester
 from ci import models

--- a/ci/client/tests/test_views.py
+++ b/ci/client/tests/test_views.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.urls import reverse
 from django.http import HttpResponseNotAllowed, HttpResponseBadRequest
 from django.test import override_settings

--- a/ci/client/urls.py
+++ b/ci/client/urls.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.conf.urls import url
 from . import views
 

--- a/ci/client/views.py
+++ b/ci/client/views.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.views.decorators.csrf import csrf_exempt
 from django.db.models import Sum
 from django.http import JsonResponse, HttpResponseNotAllowed, HttpResponseBadRequest

--- a/ci/event.py
+++ b/ci/event.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import models
 import logging
 import re

--- a/ci/forms.py
+++ b/ci/forms.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django import forms
 from ci import models
 

--- a/ci/git_api.py
+++ b/ci/git_api.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import abc
 
 class GitException(Exception):

--- a/ci/github/api.py
+++ b/ci/github/api.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.urls import reverse
 import logging
 from ci.git_api import GitAPI, GitException, copydoc

--- a/ci/github/oauth.py
+++ b/ci/github/oauth.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci.oauth_api import OAuth
 from django.conf import settings
 from django.urls import reverse

--- a/ci/github/tests/test_api.py
+++ b/ci/github/tests/test_api.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.urls import reverse
 from django.test import override_settings
 import requests

--- a/ci/github/tests/test_oauth.py
+++ b/ci/github/tests/test_oauth.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import TestCase, RequestFactory, Client
 from django.urls import reverse
 from django.test import override_settings

--- a/ci/github/tests/test_views.py
+++ b/ci/github/tests/test_views.py
@@ -82,7 +82,7 @@ class Tests(DBTester.DBTester):
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
         self.compare_counts(num_git_events=1)
         self.assertEqual(mock_get.call_count, 0)
         self.assertEqual(mock_del.call_count, 0)
@@ -93,7 +93,7 @@ class Tests(DBTester.DBTester):
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
         self.compare_counts(num_git_events=1)
         self.assertEqual(mock_get.call_count, 0)
         self.assertEqual(mock_del.call_count, 0)
@@ -105,7 +105,7 @@ class Tests(DBTester.DBTester):
         mock_get.call_count = 0
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
         self.compare_counts(jobs=2,
                 ready=1,
                 events=1,
@@ -130,7 +130,7 @@ class Tests(DBTester.DBTester):
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
         self.compare_counts(pr_closed=True, num_git_events=1)
         self.assertEqual(mock_get.call_count, 1) # for changed files
         self.assertEqual(mock_del.call_count, 0)
@@ -142,7 +142,7 @@ class Tests(DBTester.DBTester):
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
         self.compare_counts(num_git_events=1)
         self.assertEqual(mock_get.call_count, 1) # for changed files
         self.assertEqual(mock_del.call_count, 0)
@@ -154,7 +154,7 @@ class Tests(DBTester.DBTester):
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
         self.compare_counts(num_git_events=1)
         self.assertEqual(mock_get.call_count, 0)
         self.assertEqual(mock_del.call_count, 0)
@@ -165,7 +165,7 @@ class Tests(DBTester.DBTester):
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 400)
-        self.assertIn("bad_action", response.content)
+        self.assertIn(b"bad_action", response.content)
         self.compare_counts(num_git_events=1)
         self.assertEqual(mock_get.call_count, 0)
         self.assertEqual(mock_del.call_count, 0)
@@ -182,7 +182,7 @@ class Tests(DBTester.DBTester):
             self.set_counts()
             response = self.client_post_json(url, py_data)
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.content, "OK")
+            self.assertEqual(response.content, b"OK")
             self.compare_counts(num_git_events=1)
             self.assertEqual(mock_get.call_count, 2) # 1 for changed files, 1 in remove_pr_todo_labels
             self.assertEqual(mock_del.call_count, 1) # for remove_pr_todo_labels
@@ -196,7 +196,7 @@ class Tests(DBTester.DBTester):
             self.set_counts()
             response = self.client_post_json(url, py_data)
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.content, "OK")
+            self.assertEqual(response.content, b"OK")
             self.compare_counts(jobs=2,
                     ready=1,
                     events=1,
@@ -228,7 +228,7 @@ class Tests(DBTester.DBTester):
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
         self.compare_counts(jobs=2, ready=1, events=1, commits=2, active=2, active_repos=1, num_git_events=1)
         ev = models.Event.objects.latest()
         self.assertEqual(ev.cause, models.Event.PUSH)
@@ -243,7 +243,7 @@ class Tests(DBTester.DBTester):
         self.set_counts()
         response = self.client_post_json(url, py_data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
         self.compare_counts(jobs=2, ready=1, events=1, commits=2, active=2, num_git_events=1)
         ev = models.Event.objects.latest()
         self.assertEqual(ev.description, "Merge commit 123456")

--- a/ci/github/tests/test_views.py
+++ b/ci/github/tests/test_views.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.urls import reverse
 from ci import models
 from ci.tests import utils

--- a/ci/github/urls.py
+++ b/ci/github/urls.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.conf.urls import url
 from ci.github import oauth, views
 

--- a/ci/github/views.py
+++ b/ci/github/views.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.views.decorators.csrf import csrf_exempt
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseNotAllowed
 import logging, traceback

--- a/ci/gitlab/api.py
+++ b/ci/gitlab/api.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.urls import reverse
 import logging
 import urllib, requests

--- a/ci/gitlab/oauth.py
+++ b/ci/gitlab/oauth.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci.oauth_api import OAuth
 from django.conf import settings
 from django.urls import reverse

--- a/ci/gitlab/tests/test_api.py
+++ b/ci/gitlab/tests/test_api.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.urls import reverse
 from django.conf import settings
 from django.test import override_settings

--- a/ci/gitlab/tests/test_oauth.py
+++ b/ci/gitlab/tests/test_oauth.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import TestCase, RequestFactory, Client
 from django.urls import reverse
 from django.conf import settings

--- a/ci/gitlab/tests/test_views.py
+++ b/ci/gitlab/tests/test_views.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.conf import settings
 from django.test import override_settings
 from django.urls import reverse

--- a/ci/gitlab/tests/test_views.py
+++ b/ci/gitlab/tests/test_views.py
@@ -300,7 +300,7 @@ class Tests(DBTester.DBTester):
         response = self.client_post_json(url, push_data)
         self.assertEqual(response.status_code, 200)
         self.compare_counts(num_git_events=1)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
 
         push_data['ref'] = "refs/heads/%s" % self.branch.name
 
@@ -308,7 +308,7 @@ class Tests(DBTester.DBTester):
         response = self.client_post_json(url, push_data)
         self.assertEqual(response.status_code, 200)
         self.compare_counts(jobs=2, ready=1, events=1, commits=2, active=2, active_repos=1, num_git_events=1)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
 
         push_data['commits'] = []
 
@@ -317,5 +317,5 @@ class Tests(DBTester.DBTester):
         response = self.client_post_json(url, push_data)
         self.assertEqual(response.status_code, 200)
         self.compare_counts(num_git_events=1)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
         self.assertEqual(mock_get.call_count, 0)

--- a/ci/gitlab/urls.py
+++ b/ci/gitlab/urls.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.conf.urls import url
 from ci.gitlab import oauth, views
 

--- a/ci/gitlab/views.py
+++ b/ci/gitlab/views.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.views.decorators.csrf import csrf_exempt
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseNotAllowed
 import logging, traceback

--- a/ci/management/commands/disable_repo.py
+++ b/ci/management/commands/disable_repo.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+from __future__ import unicode_literals
 from django.core.management.base import BaseCommand, CommandError
 from ci import models
 

--- a/ci/management/commands/dump_latest.py
+++ b/ci/management/commands/dump_latest.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.core.management.base import BaseCommand
 from ci import models
 from django.core import serializers

--- a/ci/management/commands/generate_test_job_files.py
+++ b/ci/management/commands/generate_test_job_files.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.core.management.base import BaseCommand
 from ci.tests import utils
 from ci.client import views

--- a/ci/management/commands/load_recipes.py
+++ b/ci/management/commands/load_recipes.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.core.management.base import BaseCommand
 from ci.recipe import RecipeCreator
 from django.conf import settings

--- a/ci/management/commands/sync_open_prs.py
+++ b/ci/management/commands/sync_open_prs.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from django.core.management.base import BaseCommand, CommandError
 from ci import models
 

--- a/ci/management/commands/user_access.py
+++ b/ci/management/commands/user_access.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 
+from __future__ import unicode_literals
 from django.core.management.base import BaseCommand, CommandError
 from ci import models
 

--- a/ci/models.py
+++ b/ci/models.py
@@ -320,7 +320,7 @@ class PullRequest(models.Model):
     last_modified = models.DateTimeField(auto_now=True)
 
     def __unicode__(self):
-        return u'#{} : {}'.format(self.number, self.title)
+        return '#{} : {}'.format(self.number, self.title)
 
     class Meta:
         get_latest_by = 'last_modified'
@@ -375,7 +375,7 @@ class Event(models.Model):
     created = models.DateTimeField(db_index=True, auto_now_add=True)
 
     def __unicode__(self):
-        return u'{} : {}'.format(self.CAUSE_CHOICES[self.cause][1], str(self.head))
+        return '{} : {}'.format(self.CAUSE_CHOICES[self.cause][1], str(self.head))
 
     class Meta:
         ordering = ['-created']
@@ -734,7 +734,7 @@ class RecipeEnvironment(models.Model):
     value = models.CharField(max_length=120)
 
     def __unicode__(self):
-        return u'{}={}'.format(self.name, self.value)
+        return '{}={}'.format(self.name, self.value)
 
 class PreStepSource(models.Model):
     """
@@ -781,7 +781,7 @@ class StepEnvironment(models.Model):
     value = models.CharField(max_length=120)
 
     def __unicode__(self):
-        return u'{}:{}'.format(self.name, self.value)
+        return '{}:{}'.format(self.name, self.value)
 
 class Client(models.Model):
     """
@@ -874,7 +874,7 @@ class Job(models.Model):
     created = models.DateTimeField(auto_now_add=True)
 
     def __unicode__(self):
-        return u'{}:{}'.format(self.recipe.name, self.config.name)
+        return '{}:{}'.format(self.recipe.name, self.config.name)
 
     def status_slug(self):
         if not self.active and self.status == JobStatus.NOT_STARTED:
@@ -1011,7 +1011,7 @@ class StepResult(models.Model):
     last_modified = models.DateTimeField(auto_now=True)
 
     def __unicode__(self):
-        return u'{}:{}'.format(self.job, self.name)
+        return '{}:{}'.format(self.job, self.name)
 
     class Meta:
         unique_together = ['job', 'position']

--- a/ci/models.py
+++ b/ci/models.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.db import models
 from django.conf import settings
 from ci.gitlab import api as gitlab_api

--- a/ci/oauth_api.py
+++ b/ci/oauth_api.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.shortcuts import redirect
 from requests_oauthlib import OAuth2Session
 from django.contrib import messages

--- a/ci/recipe/RecipeCreator.py
+++ b/ci/recipe/RecipeCreator.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.conf import settings
 from django.db import transaction
 import file_utils

--- a/ci/recipe/RecipeReader.py
+++ b/ci/recipe/RecipeReader.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import ConfigParser
 import file_utils
 import os, re

--- a/ci/recipe/RecipeRepoReader.py
+++ b/ci/recipe/RecipeRepoReader.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import os, fnmatch
 from RecipeReader import RecipeReader
 

--- a/ci/recipe/RecipeWriter.py
+++ b/ci/recipe/RecipeWriter.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import ConfigParser
 import os
 import file_utils

--- a/ci/recipe/file_utils.py
+++ b/ci/recipe/file_utils.py
@@ -78,7 +78,7 @@ def get_repo_sha(base_dir):
     """
     try:
         sha = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=base_dir)
-        return sha.strip()
+        return sha.decode('utf-8').strip()
     except Exception as e:
         print("Failed to get repo sha for '%s': %s" % (base_dir, e))
         return ""
@@ -97,7 +97,7 @@ def get_file_sha(repo_dir, filename):
         if not sha:
             return ""
         sha = subprocess.check_output(['git', 'hash-object', filename], cwd=repo_dir)
-        return sha.strip()
+        return sha.decode('utf-8').strip()
     except Exception as e:
         print("Failed to get sha for '%s/%s': %s" % (repo_dir, filename, e))
         return ""

--- a/ci/recipe/file_utils.py
+++ b/ci/recipe/file_utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import os
 import subprocess
 

--- a/ci/recipe/recipe_to_bash.py
+++ b/ci/recipe/recipe_to_bash.py
@@ -17,6 +17,7 @@
 Converts a recipe given in a .cfg file into a full bash shell script
 which would be similar to what CIVET would end up running.
 """
+from __future__ import unicode_literals
 import argparse, sys, os
 import re
 from RecipeReader import RecipeReader

--- a/ci/recipe/tests/RecipeTester.py
+++ b/ci/recipe/tests/RecipeTester.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci.tests import utils as test_utils
 from ci.tests import DBTester
 import os, subprocess

--- a/ci/recipe/tests/test_RecipeCreator.py
+++ b/ci/recipe/tests/test_RecipeCreator.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import RecipeTester
 from ci.tests import utils as test_utils
 from ci import models

--- a/ci/recipe/tests/test_RecipeReader.py
+++ b/ci/recipe/tests/test_RecipeReader.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci.recipe.RecipeReader import RecipeReader
 import RecipeTester
 from ci.tests import utils

--- a/ci/recipe/tests/test_RecipeRepoReader.py
+++ b/ci/recipe/tests/test_RecipeRepoReader.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci.recipe import RecipeWriter
 from ci.recipe import RecipeRepoReader
 from ci.tests import utils

--- a/ci/recipe/tests/test_RecipeWriter.py
+++ b/ci/recipe/tests/test_RecipeWriter.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci.recipe.RecipeReader import RecipeReader
 from ci.recipe import RecipeWriter
 from ci.tests import utils

--- a/ci/recipe/tests/test_file_utils.py
+++ b/ci/recipe/tests/test_file_utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci.recipe import file_utils
 import RecipeTester
 from ci.tests import utils

--- a/ci/templatetags/range.py
+++ b/ci/templatetags/range.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.template import Library
 
 register = Library()

--- a/ci/templatetags/settings_export.py
+++ b/ci/templatetags/settings_export.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django import template
 from django.conf import settings
 from django.urls import reverse

--- a/ci/tests/DBTester.py
+++ b/ci/tests/DBTester.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import TestCase, Client
 from django.conf import settings
 from ci import models

--- a/ci/tests/SeleniumTester.py
+++ b/ci/tests/SeleniumTester.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import override_settings
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from selenium import webdriver

--- a/ci/tests/test_DebugViews.py
+++ b/ci/tests/test_DebugViews.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.urls import reverse
 from django.test import override_settings
 from mock import patch

--- a/ci/tests/test_EventsStatus.py
+++ b/ci/tests/test_EventsStatus.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import DBTester
 import utils
 import datetime

--- a/ci/tests/test_GitCommitData.py
+++ b/ci/tests/test_GitCommitData.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci import models, GitCommitData
 import DBTester
 import utils

--- a/ci/tests/test_ManualEvent.py
+++ b/ci/tests/test_ManualEvent.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci import models, ManualEvent
 import DBTester
 import utils

--- a/ci/tests/test_Permissions.py
+++ b/ci/tests/test_Permissions.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from mock import patch
 from ci import models, Permissions
 from django.test import override_settings

--- a/ci/tests/test_PullRequestEvent.py
+++ b/ci/tests/test_PullRequestEvent.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci import models, PullRequestEvent, GitCommitData
 from django.test import override_settings
 from ci.github import api

--- a/ci/tests/test_PushEvent.py
+++ b/ci/tests/test_PushEvent.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci import models, PushEvent, GitCommitData
 import DBTester
 import utils

--- a/ci/tests/test_RepositoryStatus.py
+++ b/ci/tests/test_RepositoryStatus.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import DBTester
 import utils
 import datetime

--- a/ci/tests/test_Stats.py
+++ b/ci/tests/test_Stats.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import DBTester
 from ci.tests import utils
 from django.urls import reverse

--- a/ci/tests/test_TimeUtils.py
+++ b/ci/tests/test_TimeUtils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import DBTester
 from ci import TimeUtils
 import datetime

--- a/ci/tests/test_commands.py
+++ b/ci/tests/test_commands.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.core import management
 from django.core.management.base import CommandError
 from django.utils.six import StringIO

--- a/ci/tests/test_event.py
+++ b/ci/tests/test_event.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from ci import models, event
 import DBTester
 import utils

--- a/ci/tests/test_event_view_selenium.py
+++ b/ci/tests/test_event_view_selenium.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import SeleniumTester
 from django.test import override_settings
 from ci import models

--- a/ci/tests/test_git_api.py
+++ b/ci/tests/test_git_api.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import override_settings
 from ci.git_api import GitAPI
 from ci.tests import utils

--- a/ci/tests/test_html_validate.py
+++ b/ci/tests/test_html_validate.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import TestCase, Client
 from django.test.client import RequestFactory
 from py_w3c.validators.html.validator import HTMLValidator

--- a/ci/tests/test_job_view_selenium.py
+++ b/ci/tests/test_job_view_selenium.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import SeleniumTester
 import utils
 from ci import models

--- a/ci/tests/test_main_view_selenium.py
+++ b/ci/tests/test_main_view_selenium.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import SeleniumTester
 import utils
 from ci import models

--- a/ci/tests/test_models.py
+++ b/ci/tests/test_models.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import TestCase
 from django.conf import settings
 from django.test import override_settings

--- a/ci/tests/test_oauth_api.py
+++ b/ci/tests/test_oauth_api.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import TestCase, Client
 from django.test import override_settings
 from ci import oauth_api

--- a/ci/tests/test_pr_view_selenium.py
+++ b/ci/tests/test_pr_view_selenium.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import SeleniumTester
 from ci import models
 from django.urls import reverse

--- a/ci/tests/test_repo_view_selenium.py
+++ b/ci/tests/test_repo_view_selenium.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import SeleniumTester
 from django.test import override_settings
 import utils

--- a/ci/tests/test_user_repo_prefs_selenium.py
+++ b/ci/tests/test_user_repo_prefs_selenium.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import SeleniumTester
 import utils
 from django.urls import reverse

--- a/ci/tests/test_views.py
+++ b/ci/tests/test_views.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.urls import reverse
 from django.test import override_settings
 from django.conf import settings

--- a/ci/tests/utils.py
+++ b/ci/tests/utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.conf import settings
 from django.test import override_settings
 from ci import models

--- a/ci/urls.py
+++ b/ci/urls.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.conf.urls import url, include
 from django.http import HttpResponse
 from . import views, DebugViews, Stats

--- a/ci/views.py
+++ b/ci/views.py
@@ -257,7 +257,7 @@ def get_job_results(request, job_id):
     tar = tarfile.open(fileobj=response, mode='w:gz')
     for result in job.step_results.all():
         info = tarfile.TarInfo(name='{}/{:02}_{}'.format(base_name, result.position, result.name))
-        s = StringIO.StringIO(result.plain_output().replace(u'\u2018', "'").replace(u"\u2019", "'"))
+        s = StringIO.StringIO(result.plain_output().replace('\u2018', "'").replace("\u2019", "'"))
         info.size = len(s.buf)
         info.mtime = time.time()
         tar.addfile(tarinfo=info, fileobj=s)

--- a/ci/views.py
+++ b/ci/views.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.shortcuts import render, redirect, get_object_or_404
 from django.views.decorators.csrf import csrf_exempt
 from django.http import HttpResponse, HttpResponseNotAllowed, HttpResponseForbidden, Http404

--- a/civet/settings.py
+++ b/civet/settings.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.conf.locale.en import formats as en_formats
 """
 Django settings for civet project.

--- a/civet/urls.py
+++ b/civet/urls.py
@@ -28,6 +28,7 @@ Including another URLconf
     1. Add an import:  from blog import urls as blog_urls
     2. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
 """
+from __future__ import unicode_literals
 from django.conf.urls import include, url
 from django.contrib import admin
 

--- a/civet/wsgi.py
+++ b/civet/wsgi.py
@@ -22,6 +22,7 @@ For more information on this file, see
 https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
 """
 
+from __future__ import unicode_literals
 import os
 
 from django.core.wsgi import get_wsgi_application

--- a/client/BaseClient.py
+++ b/client/BaseClient.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import logging, logging.handlers
 from JobGetter import JobGetter
 from JobRunner import JobRunner

--- a/client/INLClient.py
+++ b/client/INLClient.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import BaseClient
 import os
 import time, traceback

--- a/client/InterruptHandler.py
+++ b/client/InterruptHandler.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import signal
 
 class InterruptHandler(object):

--- a/client/JobGetter.py
+++ b/client/JobGetter.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import requests
 import traceback
 import json

--- a/client/JobGetter.py
+++ b/client/JobGetter.py
@@ -37,7 +37,7 @@ class JobGetter(object):
         """
         super(JobGetter, self).__init__()
         self.client_info = client_info
-        self._headers = {"User-Agent": "INL-CIVET-Client/1.0 (+https://github.com/idaholab/civet)"}
+        self._headers = {b"User-Agent": b"INL-CIVET-Client/1.0 (+https://github.com/idaholab/civet)"}
 
     def find_job(self):
         """

--- a/client/JobRunner.py
+++ b/client/JobRunner.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import os, re, time
 import tempfile
 import subprocess, platform

--- a/client/JobRunner.py
+++ b/client/JobRunner.py
@@ -424,8 +424,8 @@ class JobRunner(object):
         proc = None
         try:
             with temp_file() as step_script:
-                step_script.write(self.all_sources)
-                step_script.write('\n%s\n' % step['script'])
+                step_script.write(self.all_sources.encode('utf-8'))
+                step_script.write(b'\n%s\n' % step['script'])
                 step_script.flush()
                 step_script.close()
                 with open(os.devnull, "wb") as devnull:

--- a/client/Modules.py
+++ b/client/Modules.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import os, subprocess
 
 class Modules(object):

--- a/client/ServerUpdater.py
+++ b/client/ServerUpdater.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import sys
 import time
 import json, requests

--- a/client/ServerUpdater.py
+++ b/client/ServerUpdater.py
@@ -214,7 +214,7 @@ class ServerUpdater(object):
             # Get rid of any possible bad characters
             for k in data.keys():
                 if isinstance(data[k], str):
-                    data[k] = data[k].decode("utf-8", "replace").encode("utf-8", "replace")
+                    data[k] = data[k].decode("utf-8", "replace")
             in_json = json.dumps(data, separators=(",", ": "))
             return in_json, True
         except Exception:

--- a/client/ServerUpdater.py
+++ b/client/ServerUpdater.py
@@ -40,7 +40,9 @@ class ServerUpdater(object):
 
         self.update_servers()
         self.running = True
-        self._headers = {"User-Agent": "INL-CIVET-Client/1.0 (+https://github.com/idaholab/civet)"}
+        # We want to make sure we don't send unicode headers
+        # Helps prevent the dreaded "Error: [('SSL routines', 'ssl3_write_pending', 'bad write retry')]" errors
+        self._headers = {b"User-Agent": b"INL-CIVET-Client/1.0 (+https://github.com/idaholab/civet)"}
 
     def update_servers(self):
         """
@@ -216,7 +218,10 @@ class ServerUpdater(object):
                 if isinstance(data[k], str):
                     data[k] = data[k].decode("utf-8", "replace")
             in_json = json.dumps(data, separators=(",", ": "))
-            return in_json, True
+            # We want to make sure the body is not unicode.
+            # Prevents the "Error: [('SSL routines', 'ssl3_write_pending', 'bad write retry')]" errors
+            # See https://github.com/urllib3/urllib3/issues/855
+            return in_json.encode("utf-8", "replace"), True
         except Exception:
             logger.warning("Failed to convert to json: \n%s\nData:%s" % (traceback.format_exc(), data))
             return {"status": "OK", "command": "stop"}, False

--- a/client/client.py
+++ b/client/client.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import argparse
 import sys, os
 import BaseClient

--- a/client/inl_client.py
+++ b/client/inl_client.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import os, sys, argparse
 import socket
 import INLClient

--- a/client/scripts/control.py
+++ b/client/scripts/control.py
@@ -22,6 +22,7 @@ This launches settings.NUM_CLIENTS instances of the INLClient and keeps them as 
 The primarly purpose and main improvement over the bash script is that this allows for easier
 restarting with a fresh copy of the client python code.
 """
+from __future__ import unicode_literals
 import sys, argparse, os
 import settings
 import subprocess

--- a/client/tests/LiveClientTester.py
+++ b/client/tests/LiveClientTester.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from ci.tests import DBTester
 import utils

--- a/client/tests/test_BaseClient.py
+++ b/client/tests/test_BaseClient.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import SimpleTestCase
 from django.test import override_settings
 from client import BaseClient

--- a/client/tests/test_BaseClient_live.py
+++ b/client/tests/test_BaseClient_live.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from client import JobGetter
 from django.test import override_settings
 from mock import patch

--- a/client/tests/test_INLClient.py
+++ b/client/tests/test_INLClient.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import SimpleTestCase
 from django.test import override_settings
 from ci.tests import utils as test_utils

--- a/client/tests/test_INLClient_live.py
+++ b/client/tests/test_INLClient_live.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import os
 from django.test import override_settings
 from mock import patch

--- a/client/tests/test_InterruptHandler.py
+++ b/client/tests/test_InterruptHandler.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import SimpleTestCase
 from django.test import override_settings
 from ci.tests import utils as test_utils

--- a/client/tests/test_JobGetter.py
+++ b/client/tests/test_JobGetter.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import requests
 from . import utils
 from django.test import override_settings

--- a/client/tests/test_JobGetter_live.py
+++ b/client/tests/test_JobGetter_live.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from client import JobGetter
 from django.test import override_settings
 from ci.tests import utils as test_utils

--- a/client/tests/test_JobRunner.py
+++ b/client/tests/test_JobRunner.py
@@ -166,7 +166,7 @@ class Tests(SimpleTestCase):
         r = self.create_runner()
         r.client_info["update_step_time"] = 1
         with JobRunner.temp_file() as script_file:
-            script = "for i in $(seq 5);do echo start $i; sleep 1; echo done $i; done"
+            script = b"for i in $(seq 5);do echo start $i; sleep 1; echo done $i; done"
             script_file.write(script)
             script_file.close()
             with open(os.devnull, "wb") as devnull:
@@ -217,7 +217,7 @@ class Tests(SimpleTestCase):
 
     def test_kill_job(self):
         with JobRunner.temp_file() as script:
-            script.write("sleep 30")
+            script.write(b"sleep 30")
             script.close()
             with open(os.devnull, "wb") as devnull:
                 r = self.create_runner()
@@ -320,7 +320,7 @@ class Tests(SimpleTestCase):
 
     def test_max_step_time(self):
         with JobRunner.temp_file() as script:
-            script.write("sleep 30")
+            script.write(b"sleep 30")
             script.close()
             with open(os.devnull, "wb") as devnull:
                 r = self.create_runner()

--- a/client/tests/test_JobRunner.py
+++ b/client/tests/test_JobRunner.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import SimpleTestCase
 from django.test import override_settings
 from ci.tests import utils as test_utils

--- a/client/tests/test_Modules.py
+++ b/client/tests/test_Modules.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import SimpleTestCase
 from django.test import override_settings
 from ci.tests import utils as test_utils

--- a/client/tests/test_Modules.py
+++ b/client/tests/test_Modules.py
@@ -53,7 +53,7 @@ class Tests(SimpleTestCase):
     @patch.object(subprocess, "Popen")
     def test_bad_output(self, mock_popen):
         mod = Modules.Modules()
-        mock_popen.return_value = MockPopen(0, "no out", "no err")
+        mock_popen.return_value = MockPopen(0, b"no out", b"no err")
         mod.command("list")
 
         with self.assertRaises(Exception):

--- a/client/tests/test_ServerUpdater.py
+++ b/client/tests/test_ServerUpdater.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import SimpleTestCase
 from django.test import override_settings
 from ci.tests import utils as test_utils

--- a/client/tests/test_ServerUpdater.py
+++ b/client/tests/test_ServerUpdater.py
@@ -293,10 +293,10 @@ class Tests(SimpleTestCase):
     def test_bad_output(self, mock_post):
         u = self.create_updater()
         mock_post.return_value = test_utils.Response({"not_empty": True})
-        item = {"server": u.main_server, "job_id": 0, "url": "url", "payload": {"output": 'foo \xe0 \xe0 bar'}}
+        item = {"server": u.main_server, "job_id": 0, "url": "url", "payload": {"output": b'foo \xe0 \xe0 bar'}}
         u.message_q.put(item)
         u.post_message(item)
-        self.assertEqual(item["payload"]["output"], "foo \xef\xbf\xbd \xef\xbf\xbd bar")
+        self.assertEqual(item["payload"]["output"], "foo \ufffd \ufffd bar")
 
         # Enforce a JSON serializable error
         class BadObject(object):

--- a/client/tests/test_ServerUpdater_live.py
+++ b/client/tests/test_ServerUpdater_live.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import time
 from django.test import override_settings
 from ci.tests import utils as test_utils

--- a/client/tests/test_client.py
+++ b/client/tests/test_client.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import SimpleTestCase
 from django.test import override_settings
 from ci.tests import utils as test_utils

--- a/client/tests/test_inl_client.py
+++ b/client/tests/test_inl_client.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 from django.test import SimpleTestCase
 from django.test import override_settings
 from ci.tests import utils as test_utils

--- a/client/tests/utils.py
+++ b/client/tests/utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import os, json
 from client import BaseClient, INLClient
 from ci.tests import utils

--- a/manage.py
+++ b/manage.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import os
 import sys
 


### PR DESCRIPTION
On python2, this makes regular strings into unicode strings. Helps prep the way for python3.
Also make sure we explicitly read/write/compare byte strings where appropriate.