### PR TITLE
On certain branches, handle push events using a "current" event.

### DIFF
--- a/ci/client/urls.py
+++ b/ci/client/urls.py
@@ -23,6 +23,7 @@ urlpatterns = [
   url(r'^claim_job/(?P<build_key>[0-9]+)/(?P<config_name>[-\w]+)/(?P<client_name>[-\w.]+)/$',
       views.claim_job, name='claim_job'),
   url(r'^ready_jobs/(?P<build_key>[0-9]+)/(?P<client_name>[-\w.]+)/$', views.ready_jobs, name='ready_jobs'),
+  url(r'^ready_jobs_html/(?P<build_key>[0-9]+)/(?P<client_name>[-\w.]+)/$', views.ready_jobs_html, name='ready_jobs_html'),
   url(r'^job_finished/(?P<build_key>[0-9]+)/(?P<client_name>[-\w.]+)/(?P<job_id>[0-9]+)/$',
       views.job_finished, name='job_finished'),
   url(r'^update_step_result/(?P<build_key>[0-9]+)/(?P<client_name>[-\w.]+)/(?P<stepresult_id>[0-9]+)/$',

--- a/ci/tests/utils.py
+++ b/ci/tests/utils.py
@@ -36,6 +36,7 @@ def base_git_config(authorized_users=[],
         remove_pr_label_prefix=["PR: [TODO]"],
         pr_wip_prefix=["WIP:", "[WIP]"],
         hostname="dummy_git_server",
+        repo_settings=None,
         ):
     return {"api_url": "https://<api_url>",
             "html_url": "https://<html_url>",
@@ -53,6 +54,7 @@ def base_git_config(authorized_users=[],
             "icon_class": icon_class,
             "pr_wip_prefix": pr_wip_prefix,
             "civet_base_url": "https://dummy_civet_server",
+            "repository_settings": repo_settings,
             }
 
 def github_config(**kwargs):


### PR DESCRIPTION
The idea is that once a push event starts running, it will run
to completion. When new events come in, events that are not
the "current" event will get cancelled. Also, the job
priorities behave differently on these events. Normal push
event jobs are sorted by priority and then by creation time.
On these special branches, event jobs are sorted by creation
time then priority. This causes all jobs on the "current" event
to run before jobs on newer events.

closes #389