### PR TITLE
Move http requests after PR job creation.

### DIFF
--- a/ci/templates/ci/ajax_test.html
+++ b/ci/templates/ci/ajax_test.html
@@ -17,7 +17,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
   <head>
-    <title>Ajax to html</title>
+    <title>JSONResponse to html</title>
   </head>
   <body>
     {{ content }}


### PR DESCRIPTION
We want to create jobs as fast as possible so
that the clients can pick them up and for the
main page to be updated properly.
Right now we are doing an http request (post) to
update job status which can take a bit of time
and possibly timeout.