### PR TITLE
Better error handling in the client

### DIFF
--- a/client/tests/test_ServerUpdater.py
+++ b/client/tests/test_ServerUpdater.py
@@ -167,13 +167,14 @@ class Tests(SimpleTestCase):
     @patch.object(requests, 'post')
     def test_send_messages_500(self, mock_post):
         u = self.create_updater()
-        # got the stop signal
-        self.load_messages(u)
-        response_data = {"status": "OK"}
-        mock_post.side_effect = [test_utils.Response(response_data), test_utils.Response(response_data, status_code=500)]
+        mock_post.return_value = test_utils.Response({"status": "OK"}, status_code=500)
+        items = self.load_messages(u)
+        self.assertEqual(u.messages, items)
+        self.assertEqual(mock_post.call_count, 0)
+        # should be cleared
         u.send_messages()
         self.assertEqual(u.messages, [])
-        self.assertEqual(mock_post.call_count, 2)
+        self.assertEqual(mock_post.call_count, 3)
 
     @patch.object(requests, 'post')
     def test_send_messages_cancel(self, mock_post):


### PR DESCRIPTION
Don't abort the civet client when the server has an internal server error