### PR TITLE
Remove the uncancelling on event completion.

### DIFF
--- a/ci/models.py
+++ b/ci/models.py
@@ -990,6 +990,7 @@ class Job(models.Model):
             self.event.set_status(status)
 
     def set_invalidated(self, message, same_client=False, client=None, check_ready=False):
+        logger.info("%s: Invalidating: %s" % (self, message))
         old_recipe = self.recipe
         self.complete = False
         latest_recipe = (Recipe.objects.filter(filename=self.recipe.filename, current=True, cause=self.recipe.cause)


### PR DESCRIPTION
This doesn't seem to be needed since we will uncancel on
job failure. This causes problems since some jobs might
not uncancel (like timing). When they finish they might
uncancel an event that shouldn't be.