### PR TITLE
Do a better job failed check when trying to uncancel an event

### DIFF
--- a/ci/client/UpdateRemoteStatus.py
+++ b/ci/client/UpdateRemoteStatus.py
@@ -193,7 +193,7 @@ def create_event_summary(request, event):
     git_api = event.build_user.api()
     ProcessCommands.edit_comment(git_api, event.build_user, event.comments_url, msg, msg_re)
 
-def pr_event_complete(request, event):
+def event_complete(request, event):
     """
     The event is complete (all jobs have finished).
     Check to see if there are "Failed but allowed"
@@ -218,12 +218,6 @@ def pr_event_complete(request, event):
     else:
         git_api.remove_pr_label(event.base.repo(), event.pull_request.number, label)
 
-def event_complete(request, event):
-    if not event.complete:
-        return
-    if event.cause == models.Event.PULL_REQUEST:
-        pr_event_complete(request, event)
-
 def start_canceled_on_fail(job):
     """
     If we auto cancel this (failed) job and it is on a push event on a configured branch,
@@ -233,12 +227,24 @@ def start_canceled_on_fail(job):
             or not job.event.auto_uncancel_previous_event()
             or job.status != models.JobStatus.FAILED):
         return
-    job_url = reverse('ci:view_job', args=[job.pk])
+
     logger.info("%s push got failed job: %s" % (job.event, job))
-    uncancel_previous_event(job.event, job_url)
 
+    failed = job.event.jobs.filter(status=models.JobStatus.FAILED).exclude(pk=job.pk).count()
 
-def uncancel_previous_event(ev, job_url):
+    if failed:
+        # If there are other jobs on this event that have failed, they would
+        # have called this function already and uncancelled any events
+        logger.info("%s already had failed job. Not trying to uncancel previous events." % job.event)
+        return
+
+    job_url = reverse('ci:view_job', args=[job.pk])
+    ev_url = reverse('ci:view_event', args=[job.event.pk])
+    msg = "Auto uncancelled due to failed <a href='%s'>job</a> on <a href='%s'>event</a>" % (job_url, ev_url)
+
+    uncancel_previous_event(job.event, msg)
+
+def uncancel_previous_event(ev, msg):
     ev_q = models.Event.objects.filter(cause=models.Event.PUSH,
             base__branch=ev.base.branch,
             created__lt=ev.created,
@@ -246,8 +252,6 @@ def uncancel_previous_event(ev, job_url):
     prev_ev = ev_q.first()
     if prev_ev:
         logger.info("%s: trying to uncancel" % prev_ev)
-        ev_url = reverse('ci:view_event', args=[ev.pk])
-        msg = "Auto uncancelled due to failed <a href='%s'>job</a> on <a href='%s'>event</a>" % (job_url, ev_url)
 
         # The whole point of uncancelling a previous event is to find one
         # that isn't going to fail. So if the previous event is already failed,
@@ -263,7 +267,7 @@ def uncancel_previous_event(ev, job_url):
 
         if failed:
             logger.info("%s: Not going to uncancel due to existing failed job(s)" % prev_ev)
-            uncancel_previous_event(prev_ev, job_url)
+            uncancel_previous_event(prev_ev, msg)
         elif jobs_to_invalidate:
             logger.info("%s: Uncancelling job(s)" % prev_ev)
             for j in jobs_to_invalidate:

--- a/ci/management/commands/cancel_old_jobs.py
+++ b/ci/management/commands/cancel_old_jobs.py
@@ -23,7 +23,7 @@ class Command(BaseCommand):
         for job in jobs.all():
             self.stdout.write("%sCancel job %s: %s: %s" % (prefix, job.pk, job, job.created))
             if not dryrun:
-                views.set_job_canceled(job, "Civet client hasn't run this job in too long a time")
+                views.set_job_canceled(job, "Canceled due to civet client not running this job in too long a time")
                 job.event.set_complete_if_done()
         if count == 0:
             self.stdout.write("No jobs to cancel")

--- a/ci/models.py
+++ b/ci/models.py
@@ -990,7 +990,7 @@ class Job(models.Model):
             self.event.set_status(status)
 
     def set_invalidated(self, message, same_client=False, client=None, check_ready=False):
-        logger.info("%s: Invalidating: %s" % (self, message))
+        logger.info("%s: %s: Invalidating: %s" % (self, self.pk, message))
         old_recipe = self.recipe
         self.complete = False
         latest_recipe = (Recipe.objects.filter(filename=self.recipe.filename, current=True, cause=self.recipe.cause)


### PR DESCRIPTION
If there is already a failed job on an event when a job fails
then we don't need to try to uncancel events since it should
have already been done.