### PR TITLE
Allow a client_runner_user in the recipe

### DIFF
--- a/ci/bitbucket/tests/test_views.py
+++ b/ci/bitbucket/tests/test_views.py
@@ -52,19 +52,22 @@ class Tests(DBTester.DBTester):
         self.assertEqual(response.status_code, 400)
         self.assertNotEqual(response.content, b"OK")
 
-        # no json
+        # not json
         user = utils.get_test_user(server=self.server)
         url = reverse('ci:bitbucket:webhook', args=[user.build_key])
         response = self.client.post(url, data)
         self.assertEqual(response.status_code, 400)
         self.assertNotEqual(response.content, b"OK")
 
-        # bad json
-        user = utils.get_test_user(self.server)
-        url = reverse('ci:bitbucket:webhook', args=[user.build_key])
+        # user with no recipes
         response = self.client_post_json(url, data)
         self.assertEqual(response.status_code, 400)
         self.assertNotEqual(response.content, b"OK")
+
+        # unknown json
+        utils.create_recipe(user=user)
+        response = self.client_post_json(url, data)
+        self.assertEqual(response.status_code, 400)
 
     def test_pull_request(self):
         url = reverse('ci:bitbucket:webhook', args=[self.build_user.build_key])

--- a/ci/bitbucket/views.py
+++ b/ci/bitbucket/views.py
@@ -130,9 +130,12 @@ def webhook(request, build_key):
 
     user = models.GitUser.objects.filter(build_key=build_key).first()
     if not user:
-        err_str = "No user with build key %s" % build_key
-        logger.warning(err_str)
-        return HttpResponseBadRequest(err_str)
+        logger.warning("No user with build key %s" % build_key)
+        return HttpResponseBadRequest("Error")
+
+    if user.recipes.count() == 0:
+        logger.warning("User '%s' does not have any recipes" % user)
+        return HttpResponseBadRequest("Error")
 
     return process_event(request, user, data)
 

--- a/ci/client/views.py
+++ b/ci/client/views.py
@@ -26,6 +26,7 @@ from django.db import transaction
 from datetime import timedelta
 from ci.client import UpdateRemoteStatus
 from django.shortcuts import render, redirect, get_object_or_404
+from django.db.models import Q
 logger = logging.getLogger('ci')
 
 def get_client_ip(request):
@@ -68,7 +69,8 @@ def ready_jobs(request, build_key, client_name):
     # a separate query with a different sort order and add those
     # to the list.
     jobs = (models.Job.objects
-            .filter(event__build_user__build_key=build_key,
+            .filter((Q(recipe__client_runner_user=None) & Q(recipe__build_user__build_key=build_key)) |
+                    Q(recipe__client_runner_user__build_key=build_key),
                 complete=False,
                 active=True,
                 ready=True,

--- a/ci/github/tests/test_views.py
+++ b/ci/github/tests/test_views.py
@@ -51,15 +51,18 @@ class Tests(DBTester.DBTester):
         response = self.client_post_json(url, data)
         self.assertEqual(response.status_code, 400)
 
-        # no json
+        # not json
         user = utils.get_test_user()
         url = reverse('ci:github:webhook', args=[user.build_key])
         response = self.client.post(url, data)
         self.assertEqual(response.status_code, 400)
 
-        # bad json
-        user = utils.get_test_user()
-        url = reverse('ci:github:webhook', args=[user.build_key])
+        # user with no recipes
+        response = self.client_post_json(url, data)
+        self.assertEqual(response.status_code, 400)
+
+        # unknown json
+        utils.create_recipe(user=user)
         response = self.client_post_json(url, data)
         self.assertEqual(response.status_code, 400)
 

--- a/ci/github/views.py
+++ b/ci/github/views.py
@@ -184,9 +184,13 @@ def webhook(request, build_key):
 
     user = models.GitUser.objects.filter(build_key=build_key).first()
     if not user:
-        err_str = "No user with build key %s" % build_key
-        logger.warning(err_str)
-        return HttpResponseBadRequest(err_str)
+        logger.warning("No user with build key %s" % build_key)
+        return HttpResponseBadRequest("Error")
+
+    if user.recipes.count() == 0:
+        logger.warning("User '%s' does not have any recipes" % user)
+        return HttpResponseBadRequest("Error")
+
     return process_event(request, user, data)
 
 def process_event(request, user, json_data):

--- a/ci/gitlab/tests/test_views.py
+++ b/ci/gitlab/tests/test_views.py
@@ -76,15 +76,18 @@ class Tests(DBTester.DBTester):
         response = self.client_post_json(url, data)
         self.assertEqual(response.status_code, 400)
 
-        # no json
+        # not json
         user = utils.get_test_user(server=self.server)
         url = reverse('ci:gitlab:webhook', args=[user.build_key])
         response = self.client.post(url, data)
         self.assertEqual(response.status_code, 400)
 
-        # bad json
-        user = utils.get_test_user(server=self.server)
-        url = reverse('ci:gitlab:webhook', args=[user.build_key])
+        # user with no recipes
+        response = self.client_post_json(url, data)
+        self.assertEqual(response.status_code, 400)
+
+        # unknown json
+        utils.create_recipe(user=user)
         response = self.client_post_json(url, data)
         self.assertEqual(response.status_code, 400)
 

--- a/ci/gitlab/views.py
+++ b/ci/gitlab/views.py
@@ -217,9 +217,12 @@ def webhook(request, build_key):
 
     user = models.GitUser.objects.filter(build_key=build_key).first()
     if not user:
-        err_str = "No user with build key %s" % build_key
-        logger.warning(err_str)
-        return HttpResponseBadRequest(err_str)
+        logger.warning("No user with build key %s" % build_key)
+        return HttpResponseBadRequest("Error")
+
+    if user.recipes.count() == 0:
+        logger.warning("User '%s' does not have any recipes" % user)
+        return HttpResponseBadRequest("Error")
 
     return process_event(request, user, data)
 

--- a/ci/models.py
+++ b/ci/models.py
@@ -668,6 +668,7 @@ class Recipe(models.Model):
     filename = models.CharField(max_length=120, blank=True)
     filename_sha = models.CharField(max_length=120, blank=True)
     build_user = models.ForeignKey(GitUser, related_name='recipes', on_delete=models.CASCADE)
+    client_runner_user = models.ForeignKey(GitUser, related_name='client_runner_recipes', on_delete=models.CASCADE, null=True)
     repository = models.ForeignKey(Repository, related_name='recipes', on_delete=models.CASCADE)
     # for push recipes this is the branch that was pushed onto
     # for PR recipes this is the branch that the PR is against

--- a/ci/recipe/RecipeCreator.py
+++ b/ci/recipe/RecipeCreator.py
@@ -428,4 +428,10 @@ class RecipeCreator(object):
 
         for team in recipe_dict["viewable_by_teams"]:
             t, created = models.RecipeViewableByTeam.objects.get_or_create(team=team, recipe=recipe)
+
+        if recipe_dict["client_runner_user"]:
+            client_runner_user_rec, created = models.GitUser.objects.get_or_create(name=recipe_dict["client_runner_user"],
+                    server=recipe.build_user.server)
+            recipe.client_runner_user = client_runner_user_rec
+
         recipe.save()

--- a/ci/recipe/RecipeReader.py
+++ b/ci/recipe/RecipeReader.py
@@ -296,6 +296,7 @@ class RecipeReader(object):
         recipe["active"] = self.get_option("Main", "active", True)
         recipe["automatic"] = self.get_option("Main", "automatic", "automatic")
         recipe["build_user"] = self.get_option("Main", "build_user", "")
+        recipe["client_runner_user"] = self.get_option("Main", "client_runner_user", "")
         recipe["build_configs"] = self.get_option("Main", "build_configs", [])
         recipe["trigger_pull_request"] = self.get_option("Main", "trigger_pull_request", False)
         recipe["priority_pull_request"] = self.get_option("Main", "priority_pull_request", 0)

--- a/ci/recipe/tests/test_RecipeCreator.py
+++ b/ci/recipe/tests/test_RecipeCreator.py
@@ -455,3 +455,17 @@ class Tests(RecipeTester.RecipeTester):
             self.check_load_recipes(recipes_dir, removed=1)
             self.compare_counts(sha_changed=True, current=-4)
 
+    def test_client_runner_user(self):
+        with test_utils.RecipeDir() as recipes_dir:
+            self.create_valid_with_check(recipes_dir)
+            build_user = models.GitUser.objects.get(name="moosebuild")
+            r = models.Recipe.objects.get(filename="recipes/pr_dep.cfg")
+            self.assertEqual(r.client_runner_user, None)
+            pr_recipe = self.find_recipe_dict("recipes/pr_dep.cfg")
+            pr_recipe["client_runner_user"] = build_user.name
+            self.write_recipe_to_repo(recipes_dir, pr_recipe, "pr_dep.cfg")
+            self.set_counts()
+            self.check_load_recipes(recipes_dir, changed=1)
+            self.compare_counts(sha_changed=True)
+            r = models.Recipe.objects.get(filename="recipes/pr_dep.cfg")
+            self.assertEqual(r.client_runner_user, build_user)

--- a/ci/tests/utils.py
+++ b/ci/tests/utils.py
@@ -194,7 +194,7 @@ def create_job(recipe=None, event=None, config=None, user=None):
         config = recipe.build_configs.first()
     return models.Job.objects.get_or_create(config=config, recipe=recipe, event=event)[0]
 
-def update_job(job, status=None, complete=None, ready=None, active=None, invalidated=None):
+def update_job(job, status=None, complete=None, ready=None, active=None, invalidated=None, client=None):
     if status is not None:
         job.status = status
     if complete is not None:
@@ -205,6 +205,8 @@ def update_job(job, status=None, complete=None, ready=None, active=None, invalid
         job.active = active
     if invalidated is not None:
         job.invalidated = invalidated
+    if client is not None:
+        job.client = client
     job.save()
 
 def create_prestepsource(filename="default.sh", recipe=None):


### PR DESCRIPTION
This would allow setting an alternate user, other than the
build_user, that will run the civet client.