### PR TITLE
Have repository badges based on job status

### DIFF
--- a/ci/client/UpdateRemoteStatus.py
+++ b/ci/client/UpdateRemoteStatus.py
@@ -290,6 +290,7 @@ def job_complete(job):
 
     ParseOutput.set_job_info(job)
     ProcessCommands.process_commands(job)
+    job.update_badge()
 
     all_done = job.event.set_complete_if_done()
 

--- a/ci/management/commands/sync_badges.py
+++ b/ci/management/commands/sync_badges.py
@@ -1,0 +1,67 @@
+from __future__ import unicode_literals, absolute_import
+from django.core.management.base import BaseCommand
+from ci import models
+
+class Command(BaseCommand):
+    help = "Sync badges"
+    def add_arguments(self, parser):
+        parser.add_argument('--dryrun', default=False, action='store_true',
+                help="Don't make any changes, just report what would have happened")
+
+    def get_repo(self, server, name):
+        try:
+            user_name, repo_name = name.split("/")
+            user = models.GitUser.objects.get(name=user_name, server=server)
+            repo = models.Repository.objects.get(name=repo_name, user=user)
+            return repo
+        except:
+            return None
+
+    def update_repo_badges(self, repo, badges, prefix, dryrun):
+        causes = [models.Event.PUSH, models.Event.MANUAL]
+        matched = []
+        for b in badges:
+            try:
+                latest_job = models.Job.objects.filter(recipe__filename=b["recipe"],
+                        event__cause__in=causes,
+                        recipe__repository=repo).latest()
+                self.stdout.write("%s%s:%s: Updating badge: %s: %s" % (prefix,
+                    repo.server(),
+                    repo,
+                    b["name"],
+                    latest_job.status_str()))
+                matched.append(b["recipe"])
+                if not dryrun:
+                    latest_job.update_badge()
+            except models.Job.DoesNotExist:
+                # no problem, the job needs to be run then the badge will be updated
+                pass
+        return matched
+
+    def handle(self, *args, **options):
+        dryrun = options["dryrun"]
+        prefix = ""
+        if dryrun:
+            prefix = "DRYRUN:"
+
+        all_matched = {}
+        for server in models.GitServer.objects.all():
+            repo_settings = server.server_config().get("repository_settings", {})
+            if not repo_settings:
+                continue
+            for name, settings in repo_settings.items():
+                badges = settings.get("badges", [])
+                if not badges:
+                    continue
+
+                repo = self.get_repo(server, name)
+                matched = self.update_repo_badges(repo, badges, prefix, dryrun)
+                if matched:
+                    all_matched[repo] = matched
+
+        for b in models.RepositoryBadge.objects.all():
+            existing = all_matched.get(b.repository, [])
+            if b.filename not in existing:
+                self.stdout.write("%s%s:%s: Removing badge: %s" % (prefix, b.repository.server(), b.repository, b.name))
+                if not dryrun:
+                    b.delete()

--- a/ci/static/ci/css/base.css
+++ b/ci/static/ci/css/base.css
@@ -88,6 +88,15 @@
   display: inline-block;
 }
 
+.badge_job_status_Failed {
+  background-color: #FF9999;
+  vertical-align: middle;
+  text-align: center;
+  width: 80px;
+  box-shadow: 1px 1px 2px #888;
+  display: inline-block;
+}
+
 .job_status_Failed_OK {
   background-color: #FFB482;
   vertical-align: middle;
@@ -104,6 +113,15 @@
   vertical-align: middle;
   text-align: center;
   width: 60px;
+  box-shadow: 1px 1px 2px #888;
+  display: inline-block;
+}
+
+.badge_job_status_Failed_OK {
+  background-color: #FFB482;
+  vertical-align: middle;
+  text-align: center;
+  width: 80px;
   box-shadow: 1px 1px 2px #888;
   display: inline-block;
 }
@@ -144,6 +162,15 @@
   vertical-align: middle;
   text-align: center;
   width: 60px;
+  box-shadow: 1px 1px 2px #888;
+  display: inline-block;
+}
+
+.badge_job_status_Passed {
+  background-color: #99FFCC;
+  vertical-align: middle;
+  text-align: center;
+  width: 80px;
   box-shadow: 1px 1px 2px #888;
   display: inline-block;
 }

--- a/ci/static/ci/js/update.js
+++ b/ci/static/ci/js/update.js
@@ -115,6 +115,12 @@ function updateReposStatus( status_data, limit )
           branch.removeClass().addClass('boxed_job_status_' + repos[i].branches[j].status);
         }
       }
+      for( var j=0, len=repos[i].badges.length; j < len; j++){
+        badge = $('#badge_' + repos[i].badges[j].id);
+        if( badge.length > 0 ){
+          badge.removeClass().addClass('badge_job_status_' + repos[i].badges[j].status);
+        }
+      }
     }
 
     var prs = repos[i].prs;

--- a/ci/templates/ci/repo_status.html
+++ b/ci/templates/ci/repo_status.html
@@ -31,6 +31,15 @@
             </span>
           {% endfor %}
         </span>
+        <span id="repo_badges_{{ repo.id }}">
+          {% for badge in repo.badges %}
+            <span id="badge_{{ badge.id }}" class="badge_job_status_{{ badge.status }}">
+              {% autoescape off %}
+                {{ badge.description }}
+              {% endautoescape %}
+            </span>
+          {% endfor %}
+        </span>
         <ul class="pr_list" id="pr_list_{{ repo.id }}">
           {% for pr in repo.prs %}
             <li id="pr_{{pr.id}}" data-sort="{{ pr.number }}">

--- a/ci/tests/DBTester.py
+++ b/ci/tests/DBTester.py
@@ -103,6 +103,7 @@ class DBCompare(object):
         self.num_events_completed = models.Event.objects.filter(complete=True).count()
         self.num_jobs_completed = models.Job.objects.filter(complete=True).count()
         self.num_viewable_teams = models.RecipeViewableByTeam.objects.count()
+        self.num_badges = models.RepositoryBadge.objects.count()
 
     def compare_counts(self, jobs=0, ready=0, events=0, recipes=0, deps=0, pr_closed=False,
         current=0, sha_changed=False, users=0, repos=0, branches=0, commits=0,
@@ -112,7 +113,7 @@ class DBCompare(object):
         num_pr_alts=0, active_repos=0, active_branches=0, repo_prefs=0,
         num_clients=0, events_canceled=0, num_changelog=0,
         num_jobs_completed=0, num_events_completed=0,
-        num_release_recipes=0,
+        num_release_recipes=0, badges=0,
         viewable_teams=0):
         self.assertEqual(self.num_jobs + jobs, models.Job.objects.count())
         self.assertEqual(self.num_jobs_ready + ready, models.Job.objects.filter(ready=True).count())
@@ -147,6 +148,7 @@ class DBCompare(object):
         self.assertEqual(self.num_events_completed + num_events_completed, models.Event.objects.filter(complete=True).count())
         self.assertEqual(self.num_jobs_completed + num_jobs_completed, models.Job.objects.filter(complete=True).count())
         self.assertEqual(self.num_viewable_teams + viewable_teams, models.RecipeViewableByTeam.objects.count())
+        self.assertEqual(self.num_badges + badges, models.RepositoryBadge.objects.count())
 
         if sha_changed:
             self.assertNotEqual(self.repo_sha, models.RecipeRepository.load().sha)

--- a/ci/tests/test_RepositoryStatus.py
+++ b/ci/tests/test_RepositoryStatus.py
@@ -32,10 +32,14 @@ class Tests(DBTester.DBTester):
                 pr = utils.create_pr(title="pr%s" % num, number=num, repo=repo)
                 pr.username = 'pr_user'
                 pr.save()
+            b = utils.create_badge(repo=repo)
+            b.status = models.JobStatus.FAILED_OK
+            b.save()
+
         active_repos = 0
         if active:
             active_repos = 3
-        self.compare_counts(users=1, repos=3, branches=9, prs=9, active_repos=active_repos)
+        self.compare_counts(users=1, repos=3, branches=9, prs=9, active_repos=active_repos, badges=3)
 
     def test_main_repos_status(self):
         self.create_repos()
@@ -50,7 +54,7 @@ class Tests(DBTester.DBTester):
             repo.save()
 
         # All repos active, no branches have their status set
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             repos = RepositoryStatus.main_repos_status()
             self.assertEqual(len(repos), 3)
             for repo in repos:
@@ -62,7 +66,7 @@ class Tests(DBTester.DBTester):
             branch.save()
 
         # All repos active, all branches active
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             repos = RepositoryStatus.main_repos_status()
             self.assertEqual(len(repos), 3)
             for repo in repos:
@@ -71,7 +75,7 @@ class Tests(DBTester.DBTester):
 
         last_modified = models.Repository.objects.first().last_modified + datetime.timedelta(0,10)
         # Nothing
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             repos = RepositoryStatus.main_repos_status(last_modified=last_modified)
             self.assertEqual(len(repos), 3)
             for repo in repos:
@@ -83,7 +87,7 @@ class Tests(DBTester.DBTester):
             pr.closed = True
             pr.save()
         # All repos active, all branches active, PRs closed
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             repos = RepositoryStatus.main_repos_status()
             self.assertEqual(len(repos), 3)
             for repo in repos:
@@ -95,7 +99,7 @@ class Tests(DBTester.DBTester):
 
         # All repos active, no branches have their status set
         pks = [models.Repository.objects.first().pk]
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             repos = RepositoryStatus.filter_repos_status(pks)
             self.assertEqual(len(repos), 1)
             for repo in repos:
@@ -107,7 +111,7 @@ class Tests(DBTester.DBTester):
 
         # None active
         q = models.Repository.objects
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             repos = RepositoryStatus.get_repos_status(repo_q=q)
             self.assertEqual(len(repos), 3)
 
@@ -119,7 +123,7 @@ class Tests(DBTester.DBTester):
         last_modified = models.Repository.objects.first().last_modified + datetime.timedelta(0,10)
         # None active
         q = models.Repository.objects
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             repos = RepositoryStatus.get_repos_status(repo_q=q, last_modified=last_modified)
             self.assertEqual(len(repos), 0)
 

--- a/ci/tests/test_models.py
+++ b/ci/tests/test_models.py
@@ -493,3 +493,7 @@ class Tests(TestCase):
         self.assertIn("1 passed", s)
         self.assertIn("2 failed", s)
         self.assertIn("3 skipped", s)
+
+    def test_repositoryBadge(self):
+        b = utils.create_badge()
+        self.assertIn("badge", b.__str__())

--- a/ci/tests/utils.py
+++ b/ci/tests/utils.py
@@ -238,6 +238,11 @@ def create_loadedmodule(name="module"):
     obj, created = models.LoadedModule.objects.get_or_create(name=name)
     return obj
 
+def create_badge(name="badge", repo=None):
+    if not repo:
+        repo = create_repo()
+    return models.RepositoryBadge.objects.get_or_create(name=name, repository=repo)[0]
+
 def _add_git_file(dirname, name):
     p = os.path.join(dirname, name)
     with open(p, 'w') as f:

--- a/civet/settings.py
+++ b/civet/settings.py
@@ -334,6 +334,10 @@ github_repo_settings = {
                 "auto_merge_require_review": True,
                 "auto_merge_label": "PR: Auto Merge",
                 "auto_merge_enabled": False,
+                "badges": [{
+                    "recipe": "recipes/moosebuild/moose/Test_deprecated.cfg",
+                    "name": "deprecated",
+                    }],
             },
         }
 


### PR DESCRIPTION
This associates a badge with a recipe, configurable in settings.py. When the latest job for that recipe completes it updates the badge status.

closes #423