### PR TITLE
Add endpoint to get events based on SHA

### DIFF
--- a/ci/templates/ci/events.html
+++ b/ci/templates/ci/events.html
@@ -19,6 +19,9 @@
 {% block content %}
 <div class="center">
   <h2>Events</h2>
+  {% if repo and sha %}
+    <h3>{{repo}}:{{sha}}</h3>
+  {% endif %}
 </div>
 
 {% include "ci/event_table.html" with events=events %}

--- a/ci/tests/test_views.py
+++ b/ci/tests/test_views.py
@@ -401,6 +401,18 @@ class Tests(DBTester.DBTester):
         response = self.client.get(reverse('ci:event_list'))
         self.assertEqual(response.status_code, 200)
 
+    def test_sha_events(self):
+        e = utils.create_event()
+        repo = e.head.branch.repository
+
+        url = reverse('ci:sha_events', args=["no_exist", repo.name, e.head.sha])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+        url = reverse('ci:sha_events', args=[repo.user.name, repo.name, e.head.sha])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
     def test_recipe_events(self):
         response = self.client.get(reverse('ci:recipe_events', args=[1000,]))
         self.assertEqual(response.status_code, 404)

--- a/ci/urls.py
+++ b/ci/urls.py
@@ -53,6 +53,8 @@ urlpatterns = [
         views.repo_branch_status, name='repo_branch_status'),
     url(r'^(?P<branch_id>[0-9]+)/branch_status.svg', views.branch_status, name='branch_status'),
     url(r'^events/', views.event_list, name='event_list'),
+    url(r'^sha_events/(?P<owner>[A-Za-z0-9_-]+)/(?P<repo>[A-Za-z0-9-_]+)/(?P<sha>[A-Za-z0-9-_]+)/$',
+        views.sha_events, name='sha_events'),
     url(r'^num_tests/', Stats.num_tests, name='num_tests'),
     url(r'^num_prs/', Stats.num_prs_by_repo, name='num_prs'),
     url(r'^pullrequests/', views.pr_list, name='pullrequest_list'),

--- a/ci/views.py
+++ b/ci/views.py
@@ -530,6 +530,15 @@ def event_list(request):
     evs_info = EventsStatus.multiline_events_info(events)
     return render(request, 'ci/events.html', {'events': evs_info, 'pages': events})
 
+def sha_events(request, owner, repo, sha):
+    repo = get_object_or_404(models.Repository.objects, name=repo, user__name=owner)
+    event_q = models.Event.objects.filter(head__branch__repository=repo, head__sha__startswith=sha)
+    event_list = EventsStatus.get_default_events_query(event_q)
+    events = get_paginated(request, event_list)
+    evs_info = EventsStatus.multiline_events_info(events)
+    return render(request, 'ci/events.html',
+            {'events': evs_info, 'pages': events, 'sha': sha, 'repo': repo})
+
 def recipe_events(request, recipe_id):
     recipe = get_object_or_404(models.Recipe, pk=recipe_id)
     event_list = (EventsStatus


### PR DESCRIPTION
@aeslaughter 
This endpoint would be something like `civet.inl.gov/sha_events/idaholab/moose/12345`
Do you have the `idaholab/moose` part while building docs? I could leave that out and only use the SHA but there could be a (small) chance that it picks up other stuff.