### PR TITLE
Enable touch based scrolling for job results

### DIFF
--- a/ci/static/ci/css/base.css
+++ b/ci/static/ci/css/base.css
@@ -20,6 +20,7 @@
   font-family: monospace;
   max-height: 50em;
   overflow-y: scroll;
+  -webkit-overflow-scrolling: touch;
 }
 
 .job_status_Running {


### PR DESCRIPTION
While being specified as 'unsupported' by the industry standard, as
well as Apple stating 'under development', we are going to enable
it because it is painful when it is not.