### PR TITLE
Fix intermittent continuation

### DIFF
--- a/ci/static/ci/css/base.css
+++ b/ci/static/ci/css/base.css
@@ -25,6 +25,7 @@
    --purple-fore: #1A0033;
    --red-fore: #330000;
    --red-back: #FF6B6B;
+   --red-light: #ffcccc;
    --yellow-back: #F4F3A1;
    --yellow-fore: #3B4504;
    --green-back: #80FFC0;
@@ -84,8 +85,11 @@ a {
   color: var(--green-fore) !important;
 }
 /*Intermittent statuses*/
-[class$="_Intermittent_Failure"], [class$="_Intermittent_Failure"] a, div[class$="_Intermittent_Failure"] {
-  background-color: var(--intermittent-back) !important;
+[class$="_Intermittent_Failure"] a {
+  color: var(--intermittent-fore) !important;
+}
+[class$="_Intermittent_Failure"], div[class$="_Intermittent_Failure"] {
+  background: repeating-linear-gradient(45deg, var(--intermittent-back), var(--intermittent-back) 10px, var(--red-light) 10px, var(--red-light) 20px)!important;
   color: var(--intermittent-fore) !important;
 }
 /*Failed OK Statuses*/
@@ -109,8 +113,11 @@ a {
   color: var(--no-status-fore);
 }
 /*Canceled Status*/
-[class$="_Canceled"], [class$="_Canceled"] a {
-  background-color: var(--canceled-back);
+[class$="_Canceled"] a {
+  color: var(--canceled-fore);
+}
+[class$="_Canceled"] {
+  background: repeating-linear-gradient(45deg, var(--canceled-back), var(--canceled-back) 10px, var(--no-status-back) 10px, var(--no-status-back) 20px)!important;
   color: var(--canceled-fore);
 }
 

--- a/client/JobRunner.py
+++ b/client/JobRunner.py
@@ -145,7 +145,8 @@ class JobRunner(object):
                 job_msg["canceled"] = True
                 break
 
-            if results.get("exit_status", 1) != 0 and step.get("abort_on_failure", True):
+            logger.info('step info: %s' % (str(results.get("exit_status", 1))) )
+            if results.get("exit_status", 1) != 85 and results.get("exit_status", 1) != 0 and step.get("abort_on_failure", True):
                 job_msg["failed"] = True
                 logger.info('Step failed. Stopping')
                 break

--- a/client/JobRunner.py
+++ b/client/JobRunner.py
@@ -145,7 +145,6 @@ class JobRunner(object):
                 job_msg["canceled"] = True
                 break
 
-            logger.info('step info: %s' % (str(results.get("exit_status", 1))) )
             if results.get("exit_status", 1) != 85 and results.get("exit_status", 1) != 0 and step.get("abort_on_failure", True):
                 job_msg["failed"] = True
                 logger.info('Step failed. Stopping')


### PR DESCRIPTION
Intermittent Failure was causing recipes to halt, when they should
be treated as a success.

Add candy stripes to some statuses (cancel and intermittent failure)