### PR TITLE
Make authorized users the default 'automatic' setting

### DIFF
--- a/ci/models.py
+++ b/ci/models.py
@@ -698,7 +698,7 @@ class Recipe(models.Model):
     create_issue_on_fail_new_comment = models.BooleanField(default=False)
     # depends_on depend on other recipes which means that it isn't symmetrical
     depends_on = models.ManyToManyField('Recipe', symmetrical=False, blank=True)
-    automatic = models.IntegerField(choices=AUTO_CHOICES, default=FULL_AUTO)
+    automatic = models.IntegerField(choices=AUTO_CHOICES, default=AUTO_FOR_AUTHORIZED)
     priority = models.PositiveIntegerField(default=0)
     activate_label = models.CharField(max_length=120, blank=True)
     last_modified = models.DateTimeField(auto_now=True)

--- a/ci/models.py
+++ b/ci/models.py
@@ -698,7 +698,7 @@ class Recipe(models.Model):
     create_issue_on_fail_new_comment = models.BooleanField(default=False)
     # depends_on depend on other recipes which means that it isn't symmetrical
     depends_on = models.ManyToManyField('Recipe', symmetrical=False, blank=True)
-    automatic = models.IntegerField(choices=AUTO_CHOICES, default=AUTO_FOR_AUTHORIZED)
+    automatic = models.IntegerField(choices=AUTO_CHOICES, default=FULL_AUTO)
     priority = models.PositiveIntegerField(default=0)
     activate_label = models.CharField(max_length=120, blank=True)
     last_modified = models.DateTimeField(auto_now=True)

--- a/ci/recipe/RecipeReader.py
+++ b/ci/recipe/RecipeReader.py
@@ -294,7 +294,7 @@ class RecipeReader(object):
         recipe["private"] = self.get_option("Main", "private", False)
         recipe["viewable_by_teams"] = self.get_option("Main", "viewable_by_teams", [])
         recipe["active"] = self.get_option("Main", "active", True)
-        recipe["automatic"] = self.get_option("Main", "automatic", "automatic")
+        recipe["automatic"] = self.get_option("Main", "automatic", "authorized")
         recipe["build_user"] = self.get_option("Main", "build_user", "")
         recipe["client_runner_user"] = self.get_option("Main", "client_runner_user", "")
         recipe["build_configs"] = self.get_option("Main", "build_configs", [])

--- a/ci/recipe/Recipe_Template.cfg
+++ b/ci/recipe/Recipe_Template.cfg
@@ -25,7 +25,7 @@ priority_push = 3
 #         "manual": The job will have to be manually activated by a collaborator before it can be run
 #         "automatic": The job automatically is scheduled to run (when dependencies are set)
 #         "authorized": The job automatically is scheduled to run if the initiated user is a collaborator
-automatic = automatic
+automatic = authorized
 # build_configs: A list of configurations that this recipe should be run against. See pyrecipe/RecipeReader.py for a list of allowed configs.
 build_configs = linux-gnu
 # allow_on_pr: If True then a user can select this recipe to be run on a pull request (if it isn't already triggered on a PR)


### PR DESCRIPTION
This PR prevents un-authorized users access to recipes which may not have automatic set.