### PR TITLE
Fix the recent event number fix

### DIFF
--- a/ci/static/ci/js/update.js
+++ b/ci/static/ci/js/update.js
@@ -72,7 +72,7 @@ function updateEvents( evs, event_limit )
   /* now limit to the max number */
   var count = 0;
   $("#event_table").find("tr").filter(function(i, e){
-    if( e.id.slice(-4) != '_999' ){
+    if( e.id.split('_').length == 2 ){
       count++;
     }
     return count > event_limit;


### PR DESCRIPTION
#463 still counted too many rows. Instead of skipping rows with the `_999` suffix we now skip all rows that have a suffix (because it could be `_998`, `_997`, etc.).

Refs #462