### PR TITLE
If bash is not found in WD, unset WD

### DIFF
--- a/client/scripts/mingw64_runcmd.bat
+++ b/client/scripts/mingw64_runcmd.bat
@@ -27,6 +27,7 @@ set MSYSTEM=MINGW64
 rem Run the provided command in a new shell (don't use the START
 rem   command, which creates a new process instead of waiting for
 rem   execution to finish).
+if NOT EXIST %WD%bash set WD=
 %WD%bash %*
 
 :EOF


### PR DESCRIPTION
This fixes a problem that RAVEN was having with running Civet in windows 10.