### PR TITLE
Expand cleanup commands to stage commands

### DIFF
--- a/client/BaseClient.py
+++ b/client/BaseClient.py
@@ -82,6 +82,7 @@ class BaseClient(object):
         self.client_info = client_info
         self.command_q = Queue()
         self.runner_error = False
+        self.runner_killed = False
         self.thread_join_wait = 2*60*60 # 2 hours
 
         if self.client_info["log_file"]:
@@ -255,6 +256,7 @@ class BaseClient(object):
                 job_id, job_info["recipe_name"]))
         self.command_q.queue.clear()
         self.runner_error = runner.error
+        self.runner_killed = runner.job_killed
 
     def run(self):
         """

--- a/client/BaseClient.py
+++ b/client/BaseClient.py
@@ -111,6 +111,9 @@ class BaseClient(object):
         if 'client_name' in self.client_info:
             self.set_environment('CIVET_CLIENT_NAME', self.client_info['client_name'])
 
+        # Entrypoint for running something after each runner step
+        self._runner_post_step = None
+
     def get_client_info(self, key):
         """
         Returns:
@@ -224,8 +227,8 @@ class BaseClient(object):
                 control_q.put({"server": entry, "message": "Job {}: {}".format(job_id, job_info["recipe_name"])})
 
         updater_thread = Thread(target=ServerUpdater.run, args=(updater,))
-        updater_thread.start();
-        runner.run_job()
+        updater_thread.start()
+        runner.run_job(post_step=self._runner_post_step)
         if not runner.stopped and not runner.canceled:
             logger.info("Joining message_q")
             message_q.join()

--- a/client/BaseClient.py
+++ b/client/BaseClient.py
@@ -210,7 +210,7 @@ class BaseClient(object):
         environment[str(var)] = str(value)
         self.set_client_info('environment', environment)
 
-    def run_claimed_job(self, server, servers, claimed):
+    def run_claimed_job(self, server, servers, claimed, fail: bool = False):
         job_info = claimed["job_info"]
         job_id = job_info["job_id"]
         build_key = claimed["build_key"]
@@ -228,7 +228,7 @@ class BaseClient(object):
 
         updater_thread = Thread(target=ServerUpdater.run, args=(updater,))
         updater_thread.start()
-        runner.run_job(post_step=self._runner_post_step)
+        runner.run_job(post_step=self._runner_post_step, fail=fail)
         if not runner.stopped and not runner.canceled:
             logger.info("Joining message_q")
             message_q.join()

--- a/client/INLClient.py
+++ b/client/INLClient.py
@@ -185,12 +185,12 @@ class INLClient(BaseClient.BaseClient):
                 # Remove the newline
                 if output_line and output_line[-1] == '\n':
                     output_line = output_line[:-1]
-                logger.info(output_line)
+                logger.info(f'CLEANUP: {output_line}')
             returncode = 0
         except subprocess.CalledProcessError as e:
             returncode = e.returncode
 
-        logger.info(f'Cleanup command completed with exit code {returncode}:')
+        logger.info(f'Cleanup command completed with exit code {returncode}')
         if returncode != 0:
             raise BaseClient.ClientException('Cleanup command failed')
 

--- a/client/INLClient.py
+++ b/client/INLClient.py
@@ -167,7 +167,7 @@ class INLClient(BaseClient.BaseClient):
                 logger.exception('Failed to create BUILD_ROOT {}'.format(build_root))
                 raise
 
-    def run_stage_command(self, stage: str, env: dict | None, check: bool = False):
+    def run_stage_command(self, stage: str, env: dict | None = None, check: bool = False):
         """
         Runs the stage command with the given stage, if any.
 

--- a/client/INLClient.py
+++ b/client/INLClient.py
@@ -189,7 +189,7 @@ class INLClient(BaseClient.BaseClient):
         cleanup_command = self.client_info.get(client_info_var)
         if not cleanup_command:
             logger.debug(f'Skipping {stage} command')
-            return
+            return True
 
         logger.info(f'Executing {stage} command "{cleanup_command}"')
 

--- a/client/INLClient.py
+++ b/client/INLClient.py
@@ -78,7 +78,9 @@ class INLClient(BaseClient.BaseClient):
 
             # Run the post job cleanup, if any
             # This will be checked for failure outside of this call
-            self.run_stage_command('post_job')
+            post_job_env = copy.deepcopy(os.environ)
+            post_job_env['CIVET_JOB_COMPLETED'] = '0' if self.runner_killed else '1'
+            self.run_stage_command('post_job', env=post_job_env)
 
             return True
         return False

--- a/client/INLClient.py
+++ b/client/INLClient.py
@@ -39,9 +39,9 @@ class INLClient(BaseClient.BaseClient):
         self.client_info["jobs_ran"] = 0
 
         # Set the step cleanup command to be called after the runner step
-        self._runner_pre_step = lambda env: self.run_stage_command('pre_step', env)
+        self._runner_pre_step = lambda env: self.run_stage_command('pre_step', env=env)
         # Set the step cleanup command to be called after the runner step
-        self._runner_post_step = lambda env: self.run_stage_command('post_step', env)
+        self._runner_post_step = lambda env: self.run_stage_command('post_step', env=env)
 
         # Whether or not a stage command failed. We reset this state every
         # time we run a job, so that we can tell if one of the stages failed
@@ -202,7 +202,7 @@ class INLClient(BaseClient.BaseClient):
         # when the script hangs for a while
         def execute_and_read():
             process_env = copy.deepcopy(os.environ)
-            if env is not None:
+            if env:
                 process_env.update(env)
             process = subprocess.Popen(cleanup_command,
                                        shell=True,

--- a/client/INLClient.py
+++ b/client/INLClient.py
@@ -216,6 +216,9 @@ class INLClient(BaseClient.BaseClient):
 
         logger.info('Available configs: {}'.format(' '.join([config for config in self.get_client_info("build_configs")])))
 
+        # Run the cleanup command on startup
+        self.run_cleanup_command()
+
         while True:
             if self.get_client_info('manage_build_root') and self.build_root_exists():
                 logger.warning("BUILD_ROOT {} already exists at beginning of poll loop; removing"

--- a/client/INLClient.py
+++ b/client/INLClient.py
@@ -216,7 +216,7 @@ class INLClient(BaseClient.BaseClient):
                 # Remove the newline
                 if output_line and output_line[-1] == '\n':
                     output_line = output_line[:-1]
-                logger.info(f'{stage}:{output_line}')
+                logger.info(f'{stage}_command:{output_line}')
             returncode = 0
         except subprocess.CalledProcessError as e:
             returncode = e.returncode

--- a/client/INLClient.py
+++ b/client/INLClient.py
@@ -247,8 +247,8 @@ class INLClient(BaseClient.BaseClient):
             None
         """
         if self.stage_commands_failed:
-            stage_list = f'[{", ".join(self.stage_commands_failed)}]'
-            raise BaseClient.ClientException(f'The staged commands {stage_list} failed')
+            stage_list = f'{", ".join(self.stage_commands_failed)}'
+            raise BaseClient.ClientException(f'The stage command(s) {stage_list} failed')
 
     def run(self, exit_if=None):
         """

--- a/client/INLClient.py
+++ b/client/INLClient.py
@@ -315,3 +315,6 @@ class INLClient(BaseClient.BaseClient):
             logger.warning("BUILD_ROOT {} still exists after exiting poll loop; removing"
                            .format(self.get_build_root()))
             self.remove_build_root()
+
+        # Run exit command
+        self.run_stage_command('exit')

--- a/client/INLClient.py
+++ b/client/INLClient.py
@@ -185,7 +185,7 @@ class INLClient(BaseClient.BaseClient):
                 # Remove the newline
                 if output_line and output_line[-1] == '\n':
                     output_line = output_line[:-1]
-                logger.info(f'CLEANUP: {output_line}')
+                logger.info(f'CLEANUP:{output_line}')
             returncode = 0
         except subprocess.CalledProcessError as e:
             returncode = e.returncode

--- a/client/INLClient.py
+++ b/client/INLClient.py
@@ -182,12 +182,15 @@ class INLClient(BaseClient.BaseClient):
 
         try:
             for output_line in execute_and_read():
+                # Remove the newline
+                if output_line and output_line[-1] == '\n':
+                    output_line = output_line[:-1]
                 logger.info(output_line)
             returncode = 0
         except subprocess.CalledProcessError as e:
             returncode = e.returncode
 
-        logger.info(f'Cleanup command result, exit code {returncode}:')
+        logger.info(f'Cleanup command completed with exit code {returncode}:')
         if returncode != 0:
             raise BaseClient.ClientException('Cleanup command failed')
 

--- a/client/INLClient.py
+++ b/client/INLClient.py
@@ -62,9 +62,12 @@ class INLClient(BaseClient.BaseClient):
             if self.get_client_info('manage_build_root'):
                 self.create_build_root()
 
+            # Run the pre_job command, if any, and fail the job if it fails
+            fail_job = not self.run_stage_command('pre_job')
+
             self.set_environment('CIVET_SERVER', self.client_info['server'])
 
-            self.run_claimed_job(server[0], [ s[0] for s in settings.SERVERS ], claimed)
+            self.run_claimed_job(server[0], [ s[0] for s in settings.SERVERS ], claimed, fail=fail_job)
             self.set_client_info('jobs_ran', self.get_client_info('jobs_ran') + 1)
 
             if self.get_client_info('manage_build_root') and self.build_root_exists():

--- a/client/JobRunner.py
+++ b/client/JobRunner.py
@@ -549,7 +549,7 @@ class JobRunner(object):
         Return:
           dict: An updated version of step_data
         """
-        if self.pre_step and not self.pre_step(step):
+        if self.pre_step and not self.pre_step(step["environment"]):
             raise StageCommandException()
 
         step_start = time.time()
@@ -570,7 +570,7 @@ class JobRunner(object):
 
         self.update_step("complete", step, step_data)
 
-        if self.post_step and not self.post_step(step):
+        if self.post_step and not self.post_step(step["environment"]):
             raise StageCommandException()
 
         return step_data

--- a/client/JobRunner.py
+++ b/client/JobRunner.py
@@ -129,7 +129,7 @@ class JobRunner(object):
             return {str(k): str(v) for k, v in env.items()}
         return {}
 
-    def run_job(self, post_step: Callable[[],bool] | None = None):
+    def run_job(self, post_step: Callable[[],bool] | None = None, fail: bool):
         """
         Runs the job as specified in the constructor.
         Inputs:
@@ -154,7 +154,10 @@ class JobRunner(object):
 
         job_id = self.job_data["job_id"]
         for step in steps:
-            results = self.run_step(step)
+            if fail:
+                self.error = True
+            else:
+                results = self.run_step(step)
 
             # Run the post step action, if any. If it fails (returns False),
             # break the poll loop

--- a/client/JobRunner.py
+++ b/client/JobRunner.py
@@ -487,7 +487,7 @@ class JobRunner(object):
                 self.kill_job(proc)
             logger.error(reason)
             self.error = True
-            step_data["output"] = err_str
+            step_data["output"] = reason
             step_data['exit_status'] = 1
             self.update_step("complete", step, step_data)
             return step_data

--- a/client/JobRunner.py
+++ b/client/JobRunner.py
@@ -15,6 +15,7 @@
 
 from __future__ import unicode_literals, absolute_import
 import os, re, time
+import copy
 import tempfile
 import subprocess, platform
 import logging
@@ -494,7 +495,7 @@ class JobRunner(object):
 
         try:
             # Execute the pre step hook, if any
-            if self.pre_step and not self.pre_step(step_env):
+            if self.pre_step and not self.pre_step(copy.deepcopy(step_env)):
                 return trigger_error(step_data, 'JobRunner pre_step failed')
 
             # Do the actual run
@@ -532,7 +533,7 @@ class JobRunner(object):
                     step_data = self.run_step_process(proc, step, step_data)
 
                 # Execute the post step hook, if any
-                if self.post_step and not self.post_step(step_env):
+                if self.post_step and not self.post_step(copy.deepcopy(step_env)):
                     return trigger_error(step_data, 'JobRunner post_step failed')
 
                 return step_data

--- a/client/JobRunner.py
+++ b/client/JobRunner.py
@@ -169,10 +169,7 @@ class JobRunner(object):
             if fail:
                 self.error = True
             else:
-                try:
-                    results = self.run_step(step)
-                except StageCommandException:
-                    self.error = True
+                results = self.run_step(step)
 
             if self.error:
                 job_msg["canceled"] = True
@@ -523,13 +520,16 @@ class JobRunner(object):
             # but there might be others
             if proc and proc.poll() is None:
                 self.kill_job(proc)
-            delimiter = '-'*60
-            err_str = "\n%s\n\n" % delimiter
-            err_str += "Unknown error occurred in the civet client! Canceling job and quitting."
-            err_str += "\nJob  : %s: %s" % (self.job_data["job_id"], self.job_data["recipe_name"])
-            err_str += "\nStep : %s" % step["step_name"]
-            err_str += "\nError:\n%s" % traceback.format_exc()
-            err_str += "\n%s" % delimiter
+            if isinstance(e, StageCommandException):
+                error_str = 'JobRunner failed due to a stage command failure'
+            else:
+                delimiter = '-'*60
+                err_str = "\n%s\n\n" % delimiter
+                err_str += "Unknown error occurred in the civet client! Canceling job and quitting."
+                err_str += "\nJob  : %s: %s" % (self.job_data["job_id"], self.job_data["recipe_name"])
+                err_str += "\nStep : %s" % step["step_name"]
+                err_str += "\nError:\n%s" % traceback.format_exc()
+                err_str += "\n%s" % delimiter
             logger.error(err_str)
             self.error = True
             step_data["output"] = err_str

--- a/client/JobRunner.py
+++ b/client/JobRunner.py
@@ -129,7 +129,7 @@ class JobRunner(object):
             return {str(k): str(v) for k, v in env.items()}
         return {}
 
-    def run_job(self, post_step: Callable[[],bool] | None = None, fail: bool):
+    def run_job(self, post_step: Callable[[],bool] | None = None, fail: bool = False):
         """
         Runs the job as specified in the constructor.
         Inputs:

--- a/client/inl_client.py
+++ b/client/inl_client.py
@@ -54,10 +54,18 @@ def commandline_client(args):
             dest='poll_time',
             help='Sets the client polling time in seconds (default: 60s)',
             default=60)
-    parser.add_argument('--cleanup-command',
+    parser.add_argument('--startup-command',
                         type=str,
-                        dest='cleanup_command',
-                        help='A cleanup command to run between jobs')
+                        dest='startup_command',
+                        help='A command to run on startup')
+    parser.add_argument('--post-job-command',
+                        type=str,
+                        dest='post_job_command',
+                        help='A command to run after a job')
+    parser.add_argument('--post-step-command',
+                        type=str,
+                        dest='post_step_command',
+                        help='A command to run after a step')
 
 
     parsed = parser.parse_args(args)
@@ -87,7 +95,9 @@ def commandline_client(args):
         # the ping message doesn't become the default message
         "server_update_interval": 50,
         "max_output_size": 5*1024*1024,
-        "cleanup_command": parsed.cleanup_command
+        "startup_command": parsed.startup_command,
+        "post_job_command": parsed.post_job_command,
+        "post_step_command": parsed.post_step_command
     }
 
     c = INLClient.INLClient(client_info)

--- a/client/inl_client.py
+++ b/client/inl_client.py
@@ -62,6 +62,10 @@ def commandline_client(args):
                         type=str,
                         dest='pre_job_command',
                         help='A command to run before a job')
+    parser.add_argument('--pre-step-command',
+                        type=str,
+                        dest='pre_step_command',
+                        help='A command to run before a step')
     parser.add_argument('--post-job-command',
                         type=str,
                         dest='post_job_command',
@@ -101,6 +105,7 @@ def commandline_client(args):
         "max_output_size": 5*1024*1024,
         "startup_command": parsed.startup_command,
         "pre_job_command": parsed.pre_job_command,
+        "pre_step_command": parsed.pre_step_command,
         "post_job_command": parsed.post_job_command,
         "post_step_command": parsed.post_step_command
     }

--- a/client/inl_client.py
+++ b/client/inl_client.py
@@ -74,7 +74,10 @@ def commandline_client(args):
                         type=str,
                         dest='post_step_command',
                         help='A command to run after a step')
-
+    parser.add_argument('--exit-command',
+                        type=str,
+                        dest='exit_command',
+                        help='A command to run on client exit')
 
     parsed = parser.parse_args(args)
     home = os.environ.get("CIVET_HOME", os.path.join(os.environ["HOME"], "civet"))
@@ -107,7 +110,8 @@ def commandline_client(args):
         "pre_job_command": parsed.pre_job_command,
         "pre_step_command": parsed.pre_step_command,
         "post_job_command": parsed.post_job_command,
-        "post_step_command": parsed.post_step_command
+        "post_step_command": parsed.post_step_command,
+        "exit_command": parsed.exit_command
     }
 
     c = INLClient.INLClient(client_info)

--- a/client/inl_client.py
+++ b/client/inl_client.py
@@ -58,6 +58,10 @@ def commandline_client(args):
                         type=str,
                         dest='startup_command',
                         help='A command to run on startup')
+    parser.add_argument('--pre-job-command',
+                        type=str,
+                        dest='pre_job_command',
+                        help='A command to run before a job')
     parser.add_argument('--post-job-command',
                         type=str,
                         dest='post_job_command',
@@ -96,6 +100,7 @@ def commandline_client(args):
         "server_update_interval": 50,
         "max_output_size": 5*1024*1024,
         "startup_command": parsed.startup_command,
+        "pre_job_command": parsed.pre_job_command,
         "post_job_command": parsed.post_job_command,
         "post_step_command": parsed.post_step_command
     }

--- a/client/tests/test_BaseClient_live.py
+++ b/client/tests/test_BaseClient_live.py
@@ -57,6 +57,7 @@ class Tests(LiveClientTester.LiveClientTester):
             c.run()
             self.compare_counts(num_clients=1, num_events_completed=1, num_jobs_completed=1, active_branches=1)
             utils.check_complete_job(self, job, c)
+            self.assertFalse(c.runner_killed)
 
     def test_run_graceful(self):
         with test_utils.RecipeDir() as recipe_dir:
@@ -73,6 +74,7 @@ class Tests(LiveClientTester.LiveClientTester):
             utils.check_complete_job(self, job, c)
             self.assertEqual(c.graceful_signal.triggered, True)
             self.assertEqual(c.cancel_signal.triggered, False)
+            self.assertFalse(c.runner_killed)
 
     def test_run_cancel(self):
         with test_utils.RecipeDir() as recipe_dir:
@@ -94,6 +96,7 @@ class Tests(LiveClientTester.LiveClientTester):
                     )
             self.assertEqual(c.cancel_signal.triggered, True)
             self.assertEqual(c.graceful_signal.triggered, False)
+            self.assertTrue(c.runner_killed)
             utils.check_canceled_job(self, job, c)
 
     def test_run_job_cancel(self):
@@ -116,6 +119,7 @@ class Tests(LiveClientTester.LiveClientTester):
                     )
             self.assertEqual(c.cancel_signal.triggered, False)
             self.assertEqual(c.graceful_signal.triggered, False)
+            self.assertTrue(c.runner_killed)
             utils.check_canceled_job(self, job, c)
 
     def test_run_job_invalidated_basic(self):
@@ -134,6 +138,7 @@ class Tests(LiveClientTester.LiveClientTester):
             self.assertGreater(15, end_time-start_time)
             self.compare_counts(invalidated=1, num_clients=1, num_changelog=1)
             utils.check_stopped_job(self, job)
+            self.assertTrue(c.runner_killed)
 
     def test_run_job_invalidated_nested_bash(self):
         with test_utils.RecipeDir() as recipe_dir:
@@ -153,6 +158,7 @@ class Tests(LiveClientTester.LiveClientTester):
             self.assertGreater(15, end_time-start_time)
             self.compare_counts(num_clients=1, invalidated=1, num_changelog=1)
             utils.check_stopped_job(self, job)
+            self.assertTrue(c.runner_killed)
 
     @patch.object(JobGetter.JobGetter, 'get_job')
     def test_exception(self, mock_getter):

--- a/client/tests/test_INLClient.py
+++ b/client/tests/test_INLClient.py
@@ -139,7 +139,7 @@ class Tests(SimpleTestCase):
             c.create_build_root()
 
     def test_run_stage_command(self):
-        for stage in ['startup', 'pre_job', 'post_job', 'pre_step', 'post_step']:
+        for stage in ['startup', 'pre_job', 'post_job', 'pre_step', 'post_step', 'exit']:
             stage_arg = f'--{stage.replace("_", "-")}-command'
             # Basic, no environment
             with tempfile.NamedTemporaryFile() as tmp:

--- a/client/tests/test_INLClient_live.py
+++ b/client/tests/test_INLClient_live.py
@@ -324,8 +324,8 @@ class Tests(LiveClientTester.LiveClientTester):
     def test_post_job_command(self):
         self.run_stage_command('post_job')
 
-    def test_post_job_command_failed(self, fail=True):
-        self.run_stage_command('post_job')
+    def test_post_job_command_failed(self):
+        self.run_stage_command('post_job', fail=True)
 
     def test_pre_step_command(self):
         self.run_stage_command('pre_step')

--- a/client/tests/test_INLClient_live.py
+++ b/client/tests/test_INLClient_live.py
@@ -41,6 +41,7 @@ class Tests(LiveClientTester.LiveClientTester):
         c.client_info["pre_step_command"] = None
         c.client_info["post_job_command"] = None
         c.client_info["post_step_command"] = None
+        c.client_info["exit_command"] = None
         return c
 
     def create_job(self, client, recipes_dir, name, sleep=1, n_steps=3, extra_script=''):
@@ -354,6 +355,9 @@ class Tests(LiveClientTester.LiveClientTester):
 
     def test_post_step_command_failed(self):
         self.run_stage_command('post_step', fail=True)
+
+    def test_exit_command(self):
+        self.run_stage_command('exit')
 
     def test_stage_commands_combined(self):
         with test_utils.RecipeDir() as recipe_dir:

--- a/client/tests/test_INLClient_live.py
+++ b/client/tests/test_INLClient_live.py
@@ -280,17 +280,17 @@ class Tests(LiveClientTester.LiveClientTester):
             with tempfile.NamedTemporaryFile() as tmp:
                 c, _ = self.create_client_and_job(recipe_dir, "RunSuccess", sleep=2)
                 self.set_counts()
-                c.client_info[f'startup_command'] = f'printf "foo=bar" > {tmp.name}'
+                c.client_info['startup_command'] = f'printf "foo=bar" > {tmp.name}'
                 c.run(exit_if=lambda _: True)
                 self.compare_counts(num_clients=1, num_events_completed=1, num_jobs_completed=1, active_branches=1)
                 self.assertEqual('foo=bar', open(tmp.name, 'r').read())
 
     def test_startup_command_failed(self):
         c = self.create_client("/foo/bar")
-        c.client_info[f'startup_command'] = f'exit 123'
+        c.client_info['startup_command'] = 'exit 123'
         with self.assertRaises(BaseClient.ClientException) as e:
             c.run()
-        self.assertEqual(f"The startup command failed", str(e.exception))
+        self.assertEqual("The startup command failed", str(e.exception))
 
     def run_stage_command(self, stage, fail=False):
         with test_utils.RecipeDir() as recipe_dir:
@@ -344,14 +344,14 @@ class Tests(LiveClientTester.LiveClientTester):
             with tempfile.TemporaryDirectory() as tmp:
                 c, _ = self.create_client_and_job(recipe_dir, "RunSuccess", sleep=2)
                 self.set_counts()
-                c.client_info[f'pre_job_command'] = f'touch {tmp}/job.pre'
-                c.client_info[f'post_job_command'] = f'mv {tmp}/job.pre {tmp}/job.post'
-                c.client_info[f'pre_step_command'] = f'touch {tmp}/step_$CIVET_STEP_NUM.pre'
-                c.client_info[f'post_step_command'] = f'mv {tmp}/step_$CIVET_STEP_NUM.pre {tmp}/step_$CIVET_STEP_NUM.post'
+                c.client_info['pre_job_command'] = f'touch {tmp}/job.pre'
+                c.client_info['post_job_command'] = f'mv {tmp}/job.pre {tmp}/job.post'
+                c.client_info['pre_step_command'] = f'touch {tmp}/step_$CIVET_STEP_NUM.pre'
+                c.client_info['post_step_command'] = f'mv {tmp}/step_$CIVET_STEP_NUM.pre {tmp}/step_$CIVET_STEP_NUM.post'
                 c.run(exit_if=lambda _: True)
                 self.compare_counts(num_clients=1, num_events_completed=1, num_jobs_completed=1, active_branches=1)
-                self.assertFalse(os.path.exists(os.path.join(tmp, f'job.pre')))
-                self.assertTrue(os.path.exists(os.path.join(tmp, f'job.post')))
+                self.assertFalse(os.path.exists(os.path.join(tmp, 'job.pre')))
+                self.assertTrue(os.path.exists(os.path.join(tmp, 'job.post')))
                 for step in [0, 1, 2]:
                     self.assertFalse(os.path.exists(os.path.join(tmp, f'step_{step}.pre')))
                     self.assertTrue(os.path.exists(os.path.join(tmp, f'step_{step}.post')))


### PR DESCRIPTION
refs #579

Adds the `--[startup,exit,pre-job,post-job,pre-step,post-step]-command` arguments to the INL client so that we can run custom scripts at those entry points. This gives us a lot of flexibility for checking job state and cleaning things up, in particular for the HPC clients we're working on. The commands executed with `--[pre,post]-step-command` also get the main environment from the step (that is, from the recipe), so that we can also do conditional things based on variables that are set in the recipes.