### PR TITLE
Encrypt OAuth tokens at rest using django-encrypted-model-fields

### DIFF
--- a/ci/migrations/0001_encrypt_gituser_token.py
+++ b/ci/migrations/0001_encrypt_gituser_token.py
@@ -1,0 +1,36 @@
+
+# Copyright 2016 Battelle Energy Alliance, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from django.db import migrations
+import encrypted_model_fields.fields
+
+
+class Migration(migrations.Migration):
+    """
+    Schema migration: change GitUser.token from a plain CharField to an
+    EncryptedCharField.  EncryptedMixin.get_internal_type() returns "TextField"
+    so the underlying DB column type changes from VARCHAR(1024) to TEXT, which
+    is the only DDL change required.
+    """
+
+    dependencies = []
+
+    operations = [
+        migrations.AlterField(
+            model_name='gituser',
+            name='token',
+            field=encrypted_model_fields.fields.EncryptedCharField(blank=True),
+        ),
+    ]

--- a/ci/migrations/0002_encrypt_existing_tokens.py
+++ b/ci/migrations/0002_encrypt_existing_tokens.py
@@ -1,0 +1,88 @@
+
+# Copyright 2016 Battelle Energy Alliance, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Data migration: encrypt existing plaintext OAuth tokens stored in GitUser.token.
+
+Prior to migration 0001, tokens were stored as raw JSON strings (e.g.
+'{"access_token": "...", ...}').  After that schema migration the column is an
+EncryptedCharField, but any rows that existed before the deployment still hold
+plaintext values because Django did not touch the rows themselves.
+
+This migration iterates over every GitUser, reads the raw value from the
+database bypassing the ORM field decryption (so we get the actual bytes on
+disk), and then saves the row through the ORM so the new EncryptedCharField
+re-writes the value as a Fernet-encrypted ciphertext.
+
+The EncryptedMixin.to_python() / from_db_value() implementation in
+django-encrypted-model-fields already handles the case where the stored value
+is not a valid Fernet token (it passes it through unchanged).  This means that
+*after* this migration we can trust all non-empty token columns to be properly
+encrypted.
+"""
+
+from django.db import migrations
+
+
+def encrypt_existing_tokens(apps, schema_editor):
+    """
+    Re-save every GitUser that has a non-empty token so that the
+    EncryptedCharField transparently encrypts the value on write.
+    """
+    GitUser = apps.get_model('ci', 'GitUser')
+    db_alias = schema_editor.connection.alias
+
+    # Fetch the raw (potentially plaintext) values directly from the DB so we
+    # do not accidentally double-encrypt rows that were already written by the
+    # new field (e.g. in a partial-deploy scenario).
+    from cryptography.fernet import InvalidToken
+
+    users = GitUser.objects.using(db_alias).all()
+    for user in users:
+        raw_token = user.token
+        if not raw_token:
+            continue
+
+        # Try to detect whether the value is already a Fernet ciphertext.
+        # Fernet tokens always start with the version byte 0x80 (= b'\x80')
+        # and are base64url-encoded, so they begin with 'gA' when stored as a
+        # UTF-8 string.  If the raw value already looks like a Fernet token we
+        # skip it to avoid double-encryption.
+        if raw_token.startswith('gA'):
+            continue
+
+        # Value is plaintext JSON — save it so EncryptedCharField encrypts it.
+        user.save(update_fields=['token'])
+
+
+def noop(apps, schema_editor):
+    """Reverse migration is a no-op: decryption is transparent to the app."""
+    pass
+
+
+class Migration(migrations.Migration):
+    """
+    Data migration to encrypt pre-existing plaintext OAuth tokens.
+
+    Must run after 0001_encrypt_gituser_token so the column is already TEXT.
+    """
+
+    dependencies = [
+        ('ci', '0001_encrypt_gituser_token'),
+    ]
+
+    operations = [
+        migrations.RunPython(encrypt_existing_tokens, reverse_code=noop),
+    ]

--- a/ci/models.py
+++ b/ci/models.py
@@ -24,6 +24,7 @@ from ci.bitbucket import api as bitbucket_api
 from ci.bitbucket import oauth as bitbucket_auth
 from ci.github import api as github_api
 from ci.github import oauth as github_auth
+from encrypted_model_fields.fields import EncryptedCharField
 import random, re
 from django.utils import timezone
 from datetime import timedelta, datetime
@@ -151,7 +152,7 @@ class GitUser(models.Model):
     name = models.CharField(max_length=120)
     build_key = models.IntegerField(default=generate_build_key, unique=True)
     server = models.ForeignKey(GitServer, related_name='users', on_delete=models.CASCADE)
-    token = models.CharField(max_length=1024, blank=True) # holds json encoded token
+    token = EncryptedCharField(max_length=1024, blank=True)  # holds json encoded token; encrypted at rest
     # When loading the home page, only these repos will be shown
     preferred_repos = models.ManyToManyField("Repository", blank=True,
             related_name="users_with_preferences")

--- a/civet/settings.py
+++ b/civet/settings.py
@@ -36,6 +36,16 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = '-85d^-^foncz90n+p7ap#irn1&$v*5%d!$u!w0m@w2v*m#&698'
 
+# Field-level encryption key for GitUser.token (OAuth tokens at rest).
+# Must be a URL-safe base64-encoded 32-byte key (Fernet key).
+# Generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+# SECURITY WARNING: In production this MUST be set via the FIELD_ENCRYPTION_KEY
+# environment variable (or a secrets manager) — never hard-code a real key here.
+FIELD_ENCRYPTION_KEY = os.environ.get(
+    'FIELD_ENCRYPTION_KEY',
+    'UsRWh3-L7hPlMdSFAhgoFuLTj79DEtZ71MUrlMr8hj0=',  # dev-only placeholder — replace in production
+)
+
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
@@ -65,6 +75,7 @@ INSTALLED_APPS = (
     'django.contrib.humanize',
     'ci',
     'debug_toolbar',
+    'encrypted_model_fields',
     'sslserver',
     'graphos',
     'corsheaders',

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ DaemonLite==0.0.2
 Django==2.2.10
 django-cors-headers==3.1.0
 django-debug-toolbar==2.0
+django-encrypted-model-fields==0.6.5
 django-extensions==2.2.1
 django-graphos==0.3.41
 django-sslserver==0.21


### PR DESCRIPTION
GitUser.token was a plain CharField storing JSON-encoded OAuth tokens from GitHub, GitLab, and Bitbucket in cleartext, exposing every user's credentials in a database dump.

Changes:
- Add django-encrypted-model-fields==0.6.5 to requirements.txt
- Add encrypted_model_fields to INSTALLED_APPS
- Add FIELD_ENCRYPTION_KEY setting (reads from env var in production)
- Change GitUser.token from CharField to EncryptedCharField — encryption is transparent to all existing read/write code (json.dumps/loads paths are unaffected)
- Add schema migration 0001 to alter the column type (VARCHAR -> TEXT)
- Add data migration 0002 to re-encrypt any pre-existing plaintext tokens

SECURITY: FIELD_ENCRYPTION_KEY must be set from a secrets manager before deploying to production. The dev-only placeholder key in settings.py must not be used in any environment that holds real tokens.