### PR TITLE
Fix open redirect in OAuth callback

### DIFF
--- a/ci/github/tests/test_oauth.py
+++ b/ci/github/tests/test_oauth.py
@@ -109,6 +109,37 @@ class Tests(TestCase):
         response = self.client.get(url, data)
         self.assertEqual(response.status_code, 302) # redirect
 
+    def test_do_redirect_same_origin_next(self):
+        """
+        A same-origin ?next= parameter must be followed after sign-out.
+        """
+        session = self.client.session
+        session[self.oauth._token_key] = 'token'
+        session[self.oauth._state_key] = 'state'
+        session[self.oauth._user_key] = 'user'
+        session.save()
+        sign_out_url = reverse('ci:github:sign_out', args=[self.server.name])
+        safe_next = reverse('ci:main')
+        response = self.client.get(sign_out_url, {'next': safe_next})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], safe_next)
+
+    def test_do_redirect_external_next_rejected(self):
+        """
+        An external URL supplied as ?next= must be rejected; the user must
+        land on the default page rather than being phished.
+        """
+        session = self.client.session
+        session[self.oauth._token_key] = 'token'
+        session[self.oauth._state_key] = 'state'
+        session[self.oauth._user_key] = 'user'
+        session.save()
+        sign_out_url = reverse('ci:github:sign_out', args=[self.server.name])
+        response = self.client.get(sign_out_url, {'next': 'https://evil.example.com/'})
+        self.assertEqual(response.status_code, 302)
+        # Must NOT redirect to the attacker's site
+        self.assertNotIn('evil.example.com', response['Location'])
+
     def test_session(self):
         user = utils.get_test_user()
         oauth = self.server.auth()

--- a/ci/oauth_api.py
+++ b/ci/oauth_api.py
@@ -15,6 +15,7 @@
 
 from __future__ import unicode_literals, absolute_import
 from django.shortcuts import redirect
+from django.utils.http import url_has_allowed_host_and_scheme
 from requests_oauthlib import OAuth2Session
 from django.contrib import messages
 import ci.models
@@ -261,14 +262,24 @@ class OAuth(object):
 
         return self.do_redirect(request)
 
+    def _safe_redirect_url(self, request, next_url, fallback='ci:main'):
+        """
+        Return next_url only if it is safe to redirect to (same host/scheme).
+        Falls back to fallback if next_url is missing or points off-site.
+        """
+        if next_url and url_has_allowed_host_and_scheme(
+                next_url,
+                allowed_hosts={request.get_host()},
+                require_https=request.is_secure()):
+            return next_url
+        return fallback
+
     def do_redirect(self, request):
         next_url = request.GET.get('next')
         if not next_url:
             next_url = request.session.get('source_url')
-            if not next_url:
-                next_url = "ci:main"
 
-        return redirect(next_url)
+        return redirect(self._safe_redirect_url(request, next_url))
 
     def sign_in(self, request):
         """

--- a/ci/tests/test_oauth_api.py
+++ b/ci/tests/test_oauth_api.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 
 from __future__ import unicode_literals, absolute_import
-from django.test import TestCase, Client
+from django.test import TestCase, Client, RequestFactory
 from django.test import override_settings
+from django.urls import reverse
 from ci import oauth_api
 from ci.tests import utils
 import json
@@ -43,3 +44,43 @@ class OAuthTestCase(TestCase):
         user.refresh_from_db()
         self.assertEqual(user.token, json.dumps(token_json))
         self.assertEqual(session[oauth._token_key], token_json)
+
+    def test_safe_redirect_url_same_origin(self):
+        """
+        A same-origin next URL (path only) must be honoured unchanged.
+        """
+        factory = RequestFactory()
+        request = factory.get('/', SERVER_NAME='testserver')
+        user = utils.get_test_user()
+        auth = user.auth()
+
+        safe_url = reverse('ci:main')
+        result = auth._safe_redirect_url(request, safe_url)
+        self.assertEqual(result, safe_url)
+
+    def test_safe_redirect_url_external_rejected(self):
+        """
+        An absolute URL pointing to a different host must be rejected
+        and the fallback returned instead.
+        """
+        factory = RequestFactory()
+        request = factory.get('/', SERVER_NAME='testserver')
+        user = utils.get_test_user()
+        auth = user.auth()
+
+        evil_url = 'https://evil.example.com/steal-credentials'
+        result = auth._safe_redirect_url(request, evil_url, fallback='ci:main')
+        self.assertEqual(result, 'ci:main')
+
+    def test_safe_redirect_url_empty_falls_back(self):
+        """
+        When next_url is None or empty the fallback must be returned.
+        """
+        factory = RequestFactory()
+        request = factory.get('/', SERVER_NAME='testserver')
+        user = utils.get_test_user()
+        auth = user.auth()
+
+        for empty in (None, ''):
+            result = auth._safe_redirect_url(request, empty, fallback='ci:main')
+            self.assertEqual(result, 'ci:main')


### PR DESCRIPTION
Validate the ?next / source_url redirect target with Django's url_has_allowed_host_and_scheme() before following it, so an attacker cannot craft a login URL that silently sends users to an external site after successful authentication. Falls back to ci:main when validation fails. Unit and integration tests added to cover same-origin (allowed), external (rejected), and empty/missing (fallback) cases.