### PR TITLE
Correct dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
       - "loganharbour"
     ignore:
       - dependency-name: "django"
-        versions: ["5.x"]
+        versions: [">=5.0,<6.0"]


### PR DESCRIPTION
We get this error from github:

```
The property '#/updates/0/ignore/0/versions' includes invalid version requirements for a pip ignore condition
```

This corrects that.