### PR TITLE
Use uppercase for dependency name in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,5 @@ updates:
     reviewers:
       - "loganharbour"
     ignore:
-      - dependency-name: "django"
+      - dependency-name: "Django"
         versions: [">=5.0,<6.0"]


### PR DESCRIPTION
We use the name 'Django' instead of 'django' in requirements